### PR TITLE
feat: allow to set page reserved height in percents

### DIFF
--- a/app/src/main/java/info/plateaukao/einkbro/preference/ConfigManager.kt
+++ b/app/src/main/java/info/plateaukao/einkbro/preference/ConfigManager.kt
@@ -130,7 +130,7 @@ class ConfigManager(
 
     var useOpenAiTts by BooleanPreference(sp, K_USE_OPENAI_TTS, true)
 
-    var pageReservedOffset: Int by IntPreference(sp, "sp_page_turn_left_value", 80)
+    var pageReservedOffset: String by StringPreference(sp, "sp_page_turn_left_value", "10%")
 
     var fontSize: Int
         get() = sp.getString(K_FONT_SIZE, "100")?.toInt() ?: 100

--- a/app/src/main/java/info/plateaukao/einkbro/view/NinjaWebView.kt
+++ b/app/src/main/java/info/plateaukao/einkbro/view/NinjaWebView.kt
@@ -646,7 +646,12 @@ open class NinjaWebView(
         return if (isVerticalRead) {
             width - 40.dp(context)
         } else {
-            height - config.pageReservedOffset.dp(context)
+            if (config.pageReservedOffset.endsWith('%')) {
+                var offsetPercent = config.pageReservedOffset.take(config.pageReservedOffset.length - 1).toInt();
+                height - height * offsetPercent / 100;
+            } else {
+                height - config.pageReservedOffset.toInt().dp(context);
+            }
         }
     }
 


### PR DESCRIPTION
Issue:
Screens have more pixels in height than in width so when offset in pixels there is a difference in scrolling on different orientations. Also it is a little bit hard to remember screen resolution in pixels and requires a few tries to get desired offset.

Solution:
Allow to input '%' character in 'Page reserved height' field for the automatic offset calculation by screen height, otherwise use pixels as before.