### PR TITLE
allow einkbro to open local html files using the content:// scheme

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -114,8 +114,13 @@
 
                 <data android:scheme="http" />
                 <data android:scheme="https" />
+                <data android:scheme="content" />
+
                 <data android:scheme="einkbro" />
                 <data android:scheme="einkbros" />
+
+                <data android:mimeType="text/html"/>
+                <data android:mimeType="application/xhtml+xml"/>
             </intent-filter>
             <intent-filter android:icon="@mipmap/ic_launcher">
                 <action android:name="android.intent.action.SEND" />

--- a/app/src/main/java/info/plateaukao/einkbro/activity/BrowserActivity.kt
+++ b/app/src/main/java/info/plateaukao/einkbro/activity/BrowserActivity.kt
@@ -1187,6 +1187,9 @@ open class BrowserActivity : FragmentActivity(), BrowserController {
                         HelperUnit.getCachedPathFromURI(this, viewUri).let {
                             addAlbum(url = "file://$it")
                         }
+                    } else if (filename?.endsWith(".html") == true || mimeType.equals("text/html")) {
+                        // local html
+                        updateAlbum(url = viewUri.toString())
                     } else {
                         // epub
                         epubManager.showEpubReader(viewUri)


### PR DESCRIPTION
This pull request will enable users to view local html files and follow local html links using einkbro. I tested it on my Onyx Boox Air 2 Plus, and it works well there.

Since I am not usually an app developer, I hope my approach here was correct. I'm very open to suggestions to fix anything.

Thanks for considering this request.