### PR TITLE
Fix bug in special handling of closing the last tab

### DIFF
--- a/app/src/main/java/info/plateaukao/einkbro/activity/BrowserActivity.kt
+++ b/app/src/main/java/info/plateaukao/einkbro/activity/BrowserActivity.kt
@@ -1919,26 +1919,28 @@ open class BrowserActivity : FragmentActivity(), BrowserController {
     }
 
     override fun removeAlbum(albumController: AlbumController, showHome: Boolean) {
-        if (browserContainer.size() <= 1) {
-            if (!showHome) {
-                finish()
+        closeTabConfirmation {
+            albumViewModel.removeAlbum(albumController.album)
+            val removeIndex = browserContainer.indexOf(albumController)
+            val currentIndex = browserContainer.indexOf(currentAlbumController)
+            browserContainer.remove(albumController)
+
+            updateSavedAlbumInfo()
+            updateWebViewCount()
+
+            if (browserContainer.isEmpty()) {
+                if (!showHome) {
+                    finish()
+                } else {
+                    ninjaWebView.loadUrl(config.favoriteUrl)
+                }
             } else {
-                ninjaWebView.loadUrl(config.favoriteUrl)
-            }
-        } else {
-            closeTabConfirmation {
-                albumViewModel.removeAlbum(albumController.album)
-                val removeIndex = browserContainer.indexOf(albumController)
-                val currentIndex = browserContainer.indexOf(currentAlbumController)
-                browserContainer.remove(albumController)
                 // only refresh album when the delete one is current one
                 if (removeIndex == currentIndex) {
                     showAlbum(browserContainer[getNextAlbumIndexAfterRemoval(removeIndex)])
                 }
-                updateWebViewCount()
             }
         }
-        updateSavedAlbumInfo()
     }
 
     private fun getNextAlbumIndexAfterRemoval(removeIndex: Int): Int =

--- a/app/src/main/java/info/plateaukao/einkbro/browser/BrowserContainer.kt
+++ b/app/src/main/java/info/plateaukao/einkbro/browser/BrowserContainer.kt
@@ -24,6 +24,8 @@ class BrowserContainer {
 
     fun size(): Int = list.size
 
+    fun isEmpty(): Boolean = list.isEmpty()
+
     fun clear() {
         for (albumController in list) {
             (albumController as NinjaWebView).destroy()


### PR DESCRIPTION
This app currently handles the closing of the last tab specially.

When closing a tab, the typical behaviors are:
- Ask user for confirmation if the settings say so.
- After the tab is closed, it is gone. If I quite the app and then reopen it, that tab will not show up again.

However, when closing the last tab, the behavior is:
- No user confirmation is requested, even if the settings say so.
- If I quite the app and then reopen it, the closed tab comes back.

This commit fixes this behavior.