### PR TITLE
Saving history at opening/closing URL

### DIFF
--- a/app/src/main/java/info/plateaukao/einkbro/activity/BrowserActivity.kt
+++ b/app/src/main/java/info/plateaukao/einkbro/activity/BrowserActivity.kt
@@ -84,6 +84,7 @@ import info.plateaukao.einkbro.preference.FabPosition
 import info.plateaukao.einkbro.preference.FontType
 import info.plateaukao.einkbro.preference.HighlightStyle
 import info.plateaukao.einkbro.preference.NewTabBehavior
+import info.plateaukao.einkbro.preference.SaveHistoryMode
 import info.plateaukao.einkbro.preference.TranslationMode
 import info.plateaukao.einkbro.preference.toggle
 import info.plateaukao.einkbro.service.ClearService
@@ -1920,6 +1921,10 @@ open class BrowserActivity : FragmentActivity(), BrowserController {
 
     override fun removeAlbum(albumController: AlbumController, showHome: Boolean) {
         closeTabConfirmation {
+            if (config.saveHistoryMode == SaveHistoryMode.SAVE_WHEN_CLOSE) {
+                addHistory(albumController.albumTitle, albumController.albumUrl)
+            }
+
             albumViewModel.removeAlbum(albumController.album)
             val removeIndex = browserContainer.indexOf(albumController)
             val currentIndex = browserContainer.indexOf(currentAlbumController)

--- a/app/src/main/java/info/plateaukao/einkbro/activity/SettingActivity.kt
+++ b/app/src/main/java/info/plateaukao/einkbro/activity/SettingActivity.kt
@@ -911,11 +911,16 @@ class SettingActivity : ComponentActivity(), KoinComponent {
             R.string.setting_summary_auto_fill_form,
             config::autoFillForm
         ),
-        BooleanSettingItem(
+        ListSettingWithEnumItem(
             R.string.setting_title_history,
             R.drawable.icon_history,
             R.string.setting_summary_history,
-            config::saveHistory
+            config::saveHistoryMode,
+            listOf(
+                R.string.save_history_mode_save_when_open,
+                R.string.save_history_mode_save_when_close,
+                R.string.save_history_mode_disabled,
+            )
         ),
         BooleanSettingItem(
             R.string.setting_title_debug,

--- a/app/src/main/java/info/plateaukao/einkbro/browser/NinjaWebViewClient.kt
+++ b/app/src/main/java/info/plateaukao/einkbro/browser/NinjaWebViewClient.kt
@@ -28,6 +28,7 @@ import info.plateaukao.einkbro.R
 import info.plateaukao.einkbro.caption.DualCaptionProcessor
 import info.plateaukao.einkbro.caption.TimedText
 import info.plateaukao.einkbro.preference.ConfigManager
+import info.plateaukao.einkbro.preference.SaveHistoryMode
 import info.plateaukao.einkbro.unit.BrowserUnit
 import info.plateaukao.einkbro.unit.HelperUnit
 import info.plateaukao.einkbro.view.NinjaToast
@@ -82,7 +83,7 @@ class NinjaWebViewClient(
         }, 1000)
 
         // skip translation pages
-        if (config.saveHistory &&
+        if (config.saveHistoryMode == SaveHistoryMode.SAVE_WHEN_OPEN &&
             !ninjaWebView.incognito &&
             !isTranslationDomain(url) &&
             url != BrowserUnit.URL_ABOUT_BLANK

--- a/app/src/main/java/info/plateaukao/einkbro/view/dialog/compose/FastToggleDialogFragment.kt
+++ b/app/src/main/java/info/plateaukao/einkbro/view/dialog/compose/FastToggleDialogFragment.kt
@@ -33,6 +33,7 @@ import info.plateaukao.einkbro.R
 import info.plateaukao.einkbro.activity.DataListActivity
 import info.plateaukao.einkbro.activity.WhiteListType
 import info.plateaukao.einkbro.preference.ConfigManager
+import info.plateaukao.einkbro.preference.SaveHistoryMode
 import info.plateaukao.einkbro.preference.toggle
 import info.plateaukao.einkbro.view.compose.MyTheme
 
@@ -100,10 +101,15 @@ fun FastToggleItemList(context: Context, config: ConfigManager, onClicked: ((Boo
             onClicked(true)
         }
         ToggleItem(
-            state = config.saveHistory,
+            state = (config.saveHistoryMode != SaveHistoryMode.DISABLED),
             titleResId = R.string.history, iconResId = R.drawable.ic_history
-        ) {
-            config::saveHistory.toggle()
+        ) { on ->
+            if (on) {
+                config.saveHistoryMode = config.toggledSaveHistoryMode
+            } else {
+                config.toggledSaveHistoryMode = config.saveHistoryMode
+                config.saveHistoryMode = SaveHistoryMode.DISABLED
+            }
             onClicked(false)
         }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -111,6 +111,9 @@
 
     <string name="setting_title_history">History</string>
     <string name="setting_summary_history">Save the history of visited websites.</string>
+    <string name="save_history_mode_save_when_open">Save when opening</string>
+    <string name="save_history_mode_save_when_close">Save when closing</string>
+    <string name="save_history_mode_disabled">Do not save</string>
 
 
     <!-- Browser clear -->


### PR DESCRIPTION
Feature Enhancement: allow user to configure when to save the history of a URL: at its opening (the original behavior) or at its closing (similar to Chrome "History: Recent Tabs").

Back compatibility with original behavior is preserved.