### PR TITLE
 Add toolbar actions to switch touch direction

### DIFF
--- a/app/src/main/java/info/plateaukao/einkbro/activity/BrowserActivity.kt
+++ b/app/src/main/java/info/plateaukao/einkbro/activity/BrowserActivity.kt
@@ -1072,6 +1072,8 @@ open class BrowserActivity : FragmentActivity(), BrowserController {
 
     override fun toggleTouchTurnPageFeature() = config::enableTouchTurn.toggle()
 
+    override fun toggleSwitchTouchAreaAction() = config::switchTouchAreaAction.toggle()
+
     private fun updateTouchView() = composeToolbarViewController.updateIcons()
 
     // Methods
@@ -1605,6 +1607,10 @@ open class BrowserActivity : FragmentActivity(), BrowserController {
                 ConfigManager.K_ENABLE_TOUCH -> {
                     updateTouchView()
                     touchController.toggleTouchPageTurn(config.enableTouchTurn)
+                }
+
+                ConfigManager.K_TOUCH_AREA_ACTION_SWITCH -> {
+                    updateTouchView()
                 }
             }
         }

--- a/app/src/main/java/info/plateaukao/einkbro/browser/BrowserController.kt
+++ b/app/src/main/java/info/plateaukao/einkbro/browser/BrowserController.kt
@@ -55,6 +55,7 @@ interface BrowserController {
     fun handleBackKey()
     fun refreshAction()
     fun toggleTouchTurnPageFeature()
+    fun toggleSwitchTouchAreaAction()
     fun showOverview()
     fun showMenuDialog()
     fun openBookmarkPage()

--- a/app/src/main/java/info/plateaukao/einkbro/view/handlers/ToolbarActionHandler.kt
+++ b/app/src/main/java/info/plateaukao/einkbro/view/handlers/ToolbarActionHandler.kt
@@ -63,6 +63,8 @@ class ToolbarActionHandler(
         ToolbarAction.Back -> browserController.handleBackKey()
         ToolbarAction.Refresh -> browserController.refreshAction()
         ToolbarAction.Touch -> browserController.toggleTouchTurnPageFeature()
+        ToolbarAction.TouchDirectionUpDown -> browserController.toggleSwitchTouchAreaAction()
+        ToolbarAction.TouchDirectionLeftRight -> browserController.toggleSwitchTouchAreaAction()
         ToolbarAction.PageUp -> browserController.pageUp()
         ToolbarAction.PageDown -> browserController.pageDown()
         ToolbarAction.TabCount -> browserController.showOverview()

--- a/app/src/main/java/info/plateaukao/einkbro/view/toolbaricons/ToolbarAction.kt
+++ b/app/src/main/java/info/plateaukao/einkbro/view/toolbaricons/ToolbarAction.kt
@@ -88,6 +88,24 @@ enum class ToolbarAction(
     MoveToBackground(
         iconResId = R.drawable.ic_minimize,
         titleResId = R.string.move_to_background
+    ),
+    TouchDirectionUpDown(
+        iconResId = R.drawable.ic_touch_direction_up,
+        titleResId = R.string.switch_touch_area_action_short,
+        iconActiveInfo = IconActiveInfo(
+            true,
+            R.drawable.ic_touch_direction_up,
+            R.drawable.ic_touch_direction_down
+        )
+    ),
+    TouchDirectionLeftRight(
+        iconResId = R.drawable.ic_touch_direction_left,
+        titleResId = R.string.switch_touch_area_action_short,
+        iconActiveInfo = IconActiveInfo(
+            true,
+            R.drawable.ic_touch_direction_left,
+            R.drawable.ic_touch_direction_right
+        )
     );
 
 

--- a/app/src/main/java/info/plateaukao/einkbro/view/viewControllers/ComposeToolbarViewController.kt
+++ b/app/src/main/java/info/plateaukao/einkbro/view/viewControllers/ComposeToolbarViewController.kt
@@ -27,6 +27,8 @@ import info.plateaukao.einkbro.view.toolbaricons.ToolbarAction.RotateScreen
 import info.plateaukao.einkbro.view.toolbaricons.ToolbarAction.Settings
 import info.plateaukao.einkbro.view.toolbaricons.ToolbarAction.TOC
 import info.plateaukao.einkbro.view.toolbaricons.ToolbarAction.Touch
+import info.plateaukao.einkbro.view.toolbaricons.ToolbarAction.TouchDirectionUpDown
+import info.plateaukao.einkbro.view.toolbaricons.ToolbarAction.TouchDirectionLeftRight
 import info.plateaukao.einkbro.view.toolbaricons.ToolbarAction.Tts
 import info.plateaukao.einkbro.view.toolbaricons.ToolbarActionInfo
 import org.koin.core.component.KoinComponent
@@ -125,6 +127,8 @@ class ComposeToolbarViewController(
                 Refresh -> ToolbarActionInfo(toolbarAction, isLoading)
                 Desktop -> ToolbarActionInfo(toolbarAction, config.desktop)
                 Touch -> ToolbarActionInfo(toolbarAction, config.enableTouchTurn)
+                TouchDirectionUpDown -> ToolbarActionInfo(toolbarAction, config.switchTouchAreaAction)
+                TouchDirectionLeftRight -> ToolbarActionInfo(toolbarAction, config.switchTouchAreaAction)
                 Tts -> ToolbarActionInfo(toolbarAction, ttsManager.isSpeaking())
                 else -> ToolbarActionInfo(toolbarAction, false)
             }

--- a/app/src/main/res/drawable/ic_touch_direction_down.xml
+++ b/app/src/main/res/drawable/ic_touch_direction_down.xml
@@ -1,0 +1,15 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <group
+      android:pivotX="12"
+      android:pivotY="12"
+      android:rotation="0"
+      android:scaleY="-1">
+    <path
+        android:fillColor="?attr/colorControlNormal"
+        android:pathData="M18.84,12.87l-4.54,-2.26c-0.17,-0.07 -0.35,-0.11 -0.54,-0.11H13v-6C13,3.67 12.33,3 11.5,3S10,3.67 10,4.5v10.74c-3.6,-0.76 -3.54,-0.75 -3.67,-0.75c-0.31,0 -0.59,0.13 -0.79,0.33l-0.79,0.8l4.94,4.94C9.96,20.83 10.34,21 10.75,21h6.79c0.75,0 1.33,-0.55 1.44,-1.28l0.75,-5.27c0.01,-0.07 0.02,-0.14 0.02,-0.2C19.75,13.63 19.37,13.09 18.84,12.87z"/>
+  </group>
+</vector>

--- a/app/src/main/res/drawable/ic_touch_direction_left.xml
+++ b/app/src/main/res/drawable/ic_touch_direction_left.xml
@@ -1,0 +1,15 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <group
+      android:pivotX="12"
+      android:pivotY="12"
+      android:rotation="270"
+      android:scaleX="-1">
+    <path
+        android:fillColor="?attr/colorControlNormal"
+        android:pathData="M18.84,12.87l-4.54,-2.26c-0.17,-0.07 -0.35,-0.11 -0.54,-0.11H13v-6C13,3.67 12.33,3 11.5,3S10,3.67 10,4.5v10.74c-3.6,-0.76 -3.54,-0.75 -3.67,-0.75c-0.31,0 -0.59,0.13 -0.79,0.33l-0.79,0.8l4.94,4.94C9.96,20.83 10.34,21 10.75,21h6.79c0.75,0 1.33,-0.55 1.44,-1.28l0.75,-5.27c0.01,-0.07 0.02,-0.14 0.02,-0.2C19.75,13.63 19.37,13.09 18.84,12.87z"/>
+  </group>
+</vector>

--- a/app/src/main/res/drawable/ic_touch_direction_right.xml
+++ b/app/src/main/res/drawable/ic_touch_direction_right.xml
@@ -1,0 +1,15 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <group
+      android:pivotX="12"
+      android:pivotY="12"
+      android:rotation="90"
+      android:scaleX="1">
+    <path
+        android:fillColor="?attr/colorControlNormal"
+        android:pathData="M18.84,12.87l-4.54,-2.26c-0.17,-0.07 -0.35,-0.11 -0.54,-0.11H13v-6C13,3.67 12.33,3 11.5,3S10,3.67 10,4.5v10.74c-3.6,-0.76 -3.54,-0.75 -3.67,-0.75c-0.31,0 -0.59,0.13 -0.79,0.33l-0.79,0.8l4.94,4.94C9.96,20.83 10.34,21 10.75,21h6.79c0.75,0 1.33,-0.55 1.44,-1.28l0.75,-5.27c0.01,-0.07 0.02,-0.14 0.02,-0.2C19.75,13.63 19.37,13.09 18.84,12.87z"/>
+  </group>
+</vector>

--- a/app/src/main/res/drawable/ic_touch_direction_up.xml
+++ b/app/src/main/res/drawable/ic_touch_direction_up.xml
@@ -1,0 +1,15 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <group
+      android:pivotX="12"
+      android:pivotY="12"
+      android:rotation="0"
+      android:scaleX="1">
+    <path
+        android:fillColor="?attr/colorControlNormal"
+        android:pathData="M18.84,12.87l-4.54,-2.26c-0.17,-0.07 -0.35,-0.11 -0.54,-0.11H13v-6C13,3.67 12.33,3 11.5,3S10,3.67 10,4.5v10.74c-3.6,-0.76 -3.54,-0.75 -3.67,-0.75c-0.31,0 -0.59,0.13 -0.79,0.33l-0.79,0.8l4.94,4.94C9.96,20.83 10.34,21 10.75,21h6.79c0.75,0 1.33,-0.55 1.44,-1.28l0.75,-5.27c0.01,-0.07 0.02,-0.14 0.02,-0.2C19.75,13.63 19.37,13.09 18.84,12.87z"/>
+  </group>
+</vector>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -306,6 +306,7 @@
     <string name="setting_summary_dark_mode">Configure dark mode.</string>
     <string name="hie_touch_area_when_input">Disable when typing</string>
     <string name="switch_touch_area_action">Switch up/down direction</string>
+    <string name="switch_touch_area_action_short">Switch direction</string>
     <string name="no_previous_page">No previous page!</string>
     <string name="setting_multitouch_use_title">Use two finger swipe</string>
     <string name="setting_multitouch_use_summary">Use two finger swipe on web content to trigger actions</string>


### PR DESCRIPTION
Originally, switching touch direction would require multiple steps. This CL adds 2 toolbar actions to allow fast switch in one step.

The new 2 toolbar actions have identical functionality and different icons. The icons are modified from original ic_touch_enabled.xml.