### PR TITLE
Fix typo under setting_title_enable_inplace_translate

### DIFF
--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -510,7 +510,7 @@
     <string name="setting_title_use_custom_gpt_url">Use Alternative Server</string>
     <string name="setting_title_custom_gpt_url">Custom Host Url</string>
     <string name="setting_summary_custom_gpt_url">Input alternative openAI server url</string>
-    <string name="setting_title_enable_inplace_translate">Tranalate paragraphs in current tab</string>
+    <string name="setting_title_enable_inplace_translate">Translate paragraphs in current tab</string>
     <string name="setting_summary_enable_inplace_translate">Show paragraph translation in current tab</string>
     <string name="setting_title_show_bookmarks_input_bar">Show Bookmarks when Inputing url</string>
     <string name="setting_summary_show_bookmarks_input_bar">Show bookmark matches when typing text in input bar.</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -437,7 +437,7 @@
     <string name="setting_title_use_custom_gpt_url">使用其他服務</string>
     <string name="setting_title_custom_gpt_url">自定義網址</string>
     <string name="setting_summary_custom_gpt_url">輸入與OpenAI APi相容的網址</string>
-    <string name="setting_title_enable_inplace_translate">Tranalate paragraphs in current tab</string>
+    <string name="setting_title_enable_inplace_translate">Translate paragraphs in current tab</string>
     <string name="setting_summary_enable_inplace_translate">Show paragraph translation in current tab</string>
     <string name="setting_title_show_bookmarks_input_bar">輸入時顯示書籤列表</string>
     <string name="setting_summary_show_bookmarks_input_bar">輸入網址時顯示符合的書籤列表</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -522,7 +522,7 @@
     <string name="setting_summary_use_custom_gpt_url">Use other API server url</string>
     <string name="setting_title_custom_gpt_url">Custom Host Url</string>
     <string name="setting_summary_custom_gpt_url">Input alternative openAI server url</string>
-    <string name="setting_title_enable_inplace_translate">Tranalate paragraphs in current tab</string>
+    <string name="setting_title_enable_inplace_translate">Translate paragraphs in current tab</string>
     <string name="setting_summary_enable_inplace_translate">Show paragraph translation in current tab</string>
     <string name="setting_title_show_bookmarks_input_bar">Show Bookmarks when Inputing url</string>
     <string name="setting_summary_show_bookmarks_input_bar">Show bookmark matches when typing text in input bar.</string>


### PR DESCRIPTION
Fix typo on the word "Translate"