### PR TITLE
Reset reader mode properly

### DIFF
--- a/app/src/main/java/info/plateaukao/einkbro/view/NinjaWebView.kt
+++ b/app/src/main/java/info/plateaukao/einkbro/view/NinjaWebView.kt
@@ -141,10 +141,16 @@ open class NinjaWebView(
             .replace("fontfamily", "fontfamily${fontNum}")
     }
 
-    override fun reload() {
+    private fun resetState(partial: Boolean = false) {
         isTranslatePage = false
-        isVerticalRead = false
-        isReaderModeOn = false
+        if (!partial) {
+            isVerticalRead = false
+            isReaderModeOn = false
+        }
+    }
+
+    override fun reload() {
+        resetState()
         settings.textZoom = config.fontSize
         settings.cacheMode = WebSettings.LOAD_DEFAULT
         super.reload()
@@ -155,9 +161,7 @@ open class NinjaWebView(
     }
 
     override fun goBack() {
-        isTranslatePage = false
-        isVerticalRead = false
-        isReaderModeOn = false
+        resetState()
         settings.textZoom = config.fontSize
         super.goBack()
     }
@@ -336,7 +340,7 @@ open class NinjaWebView(
         }
 
         dualCaption = null
-        isTranslatePage = false
+        resetState()
         isTranslateByParagraph = false
         browserController?.resetTranslateUI()
 
@@ -355,12 +359,12 @@ open class NinjaWebView(
         dualCaption = null
         album.isLoaded = true
 
-        isTranslatePage = false
+        val partial = url.startsWith("javascript:") || url.startsWith("content:")
+        resetState(partial)
         isTranslateByParagraph = false
         browserController?.resetTranslateUI()
 
-        if (url.startsWith("javascript:") || url.startsWith("content:")) {
-            // Daniel
+        if (partial) {  // Daniel
             super.loadUrl(url)
             return
         }


### PR DESCRIPTION
Currently, NinjaWebView does not reset reader mode properly. Apparently, reset logics are inconsistent across various methods. This code change introduces resetState() method to solve that.

I'm thinking that other fields should be included in resetState() as well: settings.textZoom, settings.cacheMode, isTranslateByParagraph. I'm not familiar with this codebase, so l'm leaving this for owner to decide.