### PR TITLE
Translation enhancement

### DIFF
--- a/app/src/main/java/info/plateaukao/einkbro/view/dialog/compose/TranslateDialogFragment.kt
+++ b/app/src/main/java/info/plateaukao/einkbro/view/dialog/compose/TranslateDialogFragment.kt
@@ -32,6 +32,9 @@ import androidx.compose.material.Divider
 import androidx.compose.material.Icon
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Done
+import androidx.compose.material.icons.filled.Save
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.MutableState
@@ -40,6 +43,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.rotate
@@ -57,7 +61,6 @@ import androidx.lifecycle.lifecycleScope
 import info.plateaukao.einkbro.R
 import info.plateaukao.einkbro.unit.ShareUtil
 import info.plateaukao.einkbro.unit.ViewUnit
-import info.plateaukao.einkbro.view.EBToast
 import info.plateaukao.einkbro.view.compose.MyTheme
 import info.plateaukao.einkbro.view.dialog.TranslationLanguageDialog
 import info.plateaukao.einkbro.viewmodel.TRANSLATE_API
@@ -373,15 +376,22 @@ private fun GptRow(
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.End,
     ) {
-        val context = LocalContext.current
         val coroutineScope = rememberCoroutineScope()
+
+        val saveIcon = Icons.Default.Save
+        var currentIcon by remember { mutableStateOf(saveIcon) }
+
+
         ActionMenuItem(
             "",
-            context.getDrawable(R.drawable.icon_menu_save),
+            iconDrawable = null,
+            imageVector = currentIcon,
             onClicked = {
                 coroutineScope.launch {
                     translationViewModel.saveTranslationResult()
-                    EBToast.show(context, R.string.toast_saved)
+                    currentIcon = Icons.Filled.Done
+                    delay(1000) // Wait for 0.5 seconds
+                    currentIcon = saveIcon
                 }
             }
         )

--- a/app/src/main/java/info/plateaukao/einkbro/view/dialog/compose/TranslateDialogFragment.kt
+++ b/app/src/main/java/info/plateaukao/einkbro/view/dialog/compose/TranslateDialogFragment.kt
@@ -33,8 +33,14 @@ import androidx.compose.material.Icon
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.ContentCopy
 import androidx.compose.material.icons.filled.Done
+import androidx.compose.material.icons.filled.KeyboardArrowUp
 import androidx.compose.material.icons.filled.Save
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material.icons.filled.Translate
+import androidx.compose.material.icons.outlined.Info
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.MutableState
@@ -233,7 +239,7 @@ private fun CloseButton(
     closeClick: () -> Unit,
 ) {
     Icon(
-        imageVector = ImageVector.vectorResource(id = R.drawable.icon_close),
+        imageVector = Icons.Default.Close,
         contentDescription = "Close Icon",
         tint = MaterialTheme.colors.onBackground,
         modifier = Modifier
@@ -249,9 +255,7 @@ private fun InfoButton(
     iconSize: Dp,
 ) {
     Icon(
-        imageVector = ImageVector.vectorResource(
-            id = if (showRequest.value) R.drawable.icon_arrow_up_gest else R.drawable.icon_info
-        ),
+        imageVector = if (showRequest.value) Icons.Default.KeyboardArrowUp else Icons.Outlined.Info,
         contentDescription = "Info Icon",
         tint = MaterialTheme.colors.onBackground,
         modifier = Modifier
@@ -270,7 +274,7 @@ private fun NaverButton(
     translateNaver: () -> Unit,
 ) {
     Icon(
-        imageVector = ImageVector.vectorResource(id = R.drawable.icon_search),
+        imageVector = Icons.Default.Search,
         contentDescription = "Naver dict icon",
         tint = MaterialTheme.colors.onBackground,
         modifier = Modifier
@@ -335,7 +339,7 @@ private fun DeepLButton(
     onTargetLanguageClick: () -> Unit,
 ) {
     Icon(
-        imageVector = ImageVector.vectorResource(id = R.drawable.ic_translate),
+        imageVector = Icons.Default.Translate,
         contentDescription = "Deepl Translate",
         tint = MaterialTheme.colors.onBackground,
         modifier = Modifier
@@ -356,7 +360,7 @@ private fun CopyButton(
 ) {
     val context = LocalContext.current
     Icon(
-        imageVector = ImageVector.vectorResource(id = R.drawable.ic_copy),
+        imageVector = Icons.Default.ContentCopy,
         contentDescription = "Copy text",
         tint = MaterialTheme.colors.onBackground,
         modifier = Modifier


### PR DESCRIPTION
This pull request refactors `TranslateDialogFragment.kt` to replace custom drawable resources with Material Design icons from the Compose library. It also introduces a dynamic icon state for the save button in the GPT row. These changes simplify the codebase and improve consistency with Material Design guidelines.

### Icon Replacement:
* [`CloseButton`](diffhunk://#diff-bc3e8c5ac242bc2136ee0e3362f86b3c2f2ae78ce2dc80839165f56b157813d0L233-R242): Replaced `ImageVector.vectorResource` with `Icons.Default.Close` for the close icon.
* [`InfoButton`](diffhunk://#diff-bc3e8c5ac242bc2136ee0e3362f86b3c2f2ae78ce2dc80839165f56b157813d0L249-R258): Updated the info icon to use `Icons.Default.KeyboardArrowUp` or `Icons.Outlined.Info` based on state.
* [`NaverButton`](diffhunk://#diff-bc3e8c5ac242bc2136ee0e3362f86b3c2f2ae78ce2dc80839165f56b157813d0L270-R277): Replaced the search icon with `Icons.Default.Search`.
* [`DeepLButton`](diffhunk://#diff-bc3e8c5ac242bc2136ee0e3362f86b3c2f2ae78ce2dc80839165f56b157813d0L335-R342): Updated the translate icon to use `Icons.Default.Translate`.
* [`CopyButton`](diffhunk://#diff-bc3e8c5ac242bc2136ee0e3362f86b3c2f2ae78ce2dc80839165f56b157813d0L356-R363): Replaced the copy icon with `Icons.Default.ContentCopy`.

### Dynamic Icon State:
* [`GptRow`](diffhunk://#diff-bc3e8c5ac242bc2136ee0e3362f86b3c2f2ae78ce2dc80839165f56b157813d0L376-R398): Introduced a dynamic state for the save button icon, toggling between `Icons.Default.Save` and `Icons.Filled.Done` based on user interaction.

### Code Cleanup:
* Removed unused import for `EBToast`.