### PR TITLE
feat: add pull-to-refresh support for WebView

### DIFF
--- a/ad-filter/src/main/java/io/github/edsuns/adfilter/impl/AdFilterImpl.kt
+++ b/ad-filter/src/main/java/io/github/edsuns/adfilter/impl/AdFilterImpl.kt
@@ -17,6 +17,7 @@ import io.github.edsuns.adfilter.impl.Constants.TAG_INSTALLATION
 import io.github.edsuns.adfilter.script.ElementHiding
 import io.github.edsuns.adfilter.script.ScriptInjection
 import io.github.edsuns.adfilter.script.Scriptlet
+import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
@@ -27,6 +28,7 @@ import java.io.File
 /**
  * Created by Edsuns@qq.com on 2021/7/29.
  */
+@OptIn(DelicateCoroutinesApi::class)
 internal class AdFilterImpl(appContext: Context) : AdFilter {
 
     private val detector: Detector = DetectorImpl()

--- a/ad-filter/src/main/java/io/github/edsuns/adfilter/impl/FilterSharedPreferences.kt
+++ b/ad-filter/src/main/java/io/github/edsuns/adfilter/impl/FilterSharedPreferences.kt
@@ -3,6 +3,7 @@ package io.github.edsuns.adfilter.impl
 import android.content.Context
 import android.content.SharedPreferences
 import androidx.core.content.edit
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
@@ -10,6 +11,7 @@ import kotlinx.serialization.json.Json
 /**
  * Created by Edsuns@qq.com on 2021/1/1.
  */
+@OptIn(ExperimentalSerializationApi::class)
 internal class FilterSharedPreferences(private val context: Context) {
 
     val hasInstallation: Boolean

--- a/ad-filter/src/main/java/io/github/edsuns/adfilter/impl/FilterViewModelImpl.kt
+++ b/ad-filter/src/main/java/io/github/edsuns/adfilter/impl/FilterViewModelImpl.kt
@@ -15,6 +15,7 @@ import io.github.edsuns.adfilter.workers.InstallationWorker
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
@@ -22,6 +23,7 @@ import kotlinx.serialization.json.Json
 /**
  * Created by Edsuns@qq.com on 2021/7/29.
  */
+@OptIn(ExperimentalSerializationApi::class)
 internal class FilterViewModelImpl(
     context: Context,
     private val filterDataLoader: FilterDataLoader,

--- a/adblock-client/src/main/java/io/github/edsuns/adblockclient/ResourceType.kt
+++ b/adblock-client/src/main/java/io/github/edsuns/adblockclient/ResourceType.kt
@@ -150,7 +150,7 @@ private object UrlResourceTypeDetector {
     private fun mapExtensions(extensions: Array<String>, contentType: ResourceType) {
         for (extension in extensions) {
             // all comparisons are in lower case, force that the extensions are in lower case
-            extensionTypeMap[extension.toLowerCase(Locale.ROOT)] = contentType
+            extensionTypeMap[extension.lowercase(Locale.ROOT)] = contentType
         }
     }
 
@@ -159,7 +159,7 @@ private object UrlResourceTypeDetector {
         val lastIndexOfDot = path.lastIndexOf('.')
         if (lastIndexOfDot > -1) {
             val fileExtension = path.substring(lastIndexOfDot + 1)
-            return extensionTypeMap[fileExtension.toLowerCase(Locale.ROOT)]
+            return extensionTypeMap[fileExtension.lowercase(Locale.ROOT)]
         }
         return null
     }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -120,6 +120,7 @@ dependencies {
     // for epub saving: html processing
     implementation(libs.jsoup)
     implementation("androidx.constraintlayout:constraintlayout:2.1.4")
+    implementation("androidx.swiperefreshlayout:swiperefreshlayout:1.1.0")
 
     implementation("androidx.room:room-runtime:2.6.1")
     implementation("androidx.room:room-ktx:2.6.1")

--- a/app/src/main/java/info/plateaukao/einkbro/EinkBroApplication.kt
+++ b/app/src/main/java/info/plateaukao/einkbro/EinkBroApplication.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package info.plateaukao.einkbro
 
 import android.Manifest
@@ -30,6 +32,7 @@ import info.plateaukao.einkbro.service.TtsManager
 import info.plateaukao.einkbro.unit.LocaleManager
 import info.plateaukao.einkbro.util.WebViewUtil
 import io.github.edsuns.adfilter.AdFilter
+import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import org.koin.android.ext.koin.androidContext
@@ -37,7 +40,7 @@ import org.koin.core.context.GlobalContext.startKoin
 import org.koin.dsl.module
 import timber.log.Timber
 
-@Suppress("DEPRECATION")
+@OptIn(DelicateCoroutinesApi::class)
 class EinkBroApplication : Application() {
 
     private val sp: SharedPreferences by lazy {

--- a/app/src/main/java/info/plateaukao/einkbro/activity/AdBlockSettingActivity.kt
+++ b/app/src/main/java/info/plateaukao/einkbro/activity/AdBlockSettingActivity.kt
@@ -110,7 +110,7 @@ fun SettingsScreen(
             TopAppBar(
                 title = { Text(text = stringResource(R.string.settings)) },
                 navigationIcon = {
-                    IconButton(onClick = { (context as ComponentActivity).onBackPressed() }) {
+                    IconButton(onClick = { (context as ComponentActivity).onBackPressedDispatcher.onBackPressed() }) {
                         Icon(Icons.AutoMirrored.Outlined.ArrowBack, contentDescription = null)
                     }
                 },

--- a/app/src/main/java/info/plateaukao/einkbro/activity/BrowserActivity.kt
+++ b/app/src/main/java/info/plateaukao/einkbro/activity/BrowserActivity.kt
@@ -1067,6 +1067,7 @@ open class BrowserActivity : FragmentActivity(), BrowserController {
         filePathCallback = null
     }
 
+    @Suppress("DEPRECATION")
     private fun saveEpub(uri: Uri) {
         val progressDialog =
             dialogManager.createProgressDialog(R.string.saving_epub).apply { show() }
@@ -1187,6 +1188,7 @@ open class BrowserActivity : FragmentActivity(), BrowserController {
             }
 
             // Manual keyboard handling for pre-R devices when status bar is hidden
+            @Suppress("DEPRECATION")
             val isFullscreen = (window.attributes.flags and WindowManager.LayoutParams.FLAG_FULLSCREEN) != 0
             if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R && isFullscreen) {
                 val rect = Rect()
@@ -1245,6 +1247,7 @@ open class BrowserActivity : FragmentActivity(), BrowserController {
         }
 
         updateTitle()
+        @Suppress("DEPRECATION")
         overridePendingTransition(0, 0)
         uiMode = resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK
 
@@ -2304,10 +2307,11 @@ open class BrowserActivity : FragmentActivity(), BrowserController {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
                 window.setDecorFitsSystemWindows(true)
             } else {
+                @Suppress("DEPRECATION")
                 window.clearFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN)
             }
         }
-        
+
         composeToolbarViewController.hide()
 
         val textOrUrl = if (ebWebView.url?.startsWith("data:") != true) {
@@ -2731,6 +2735,7 @@ open class BrowserActivity : FragmentActivity(), BrowserController {
         showToolbar()
     }
 
+    @Suppress("DEPRECATION")
     private fun hideStatusBar() {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
             window.setDecorFitsSystemWindows(false)
@@ -2744,6 +2749,7 @@ open class BrowserActivity : FragmentActivity(), BrowserController {
     }
 
 
+    @Suppress("DEPRECATION")
     private fun showStatusBar() {
         if (config.hideStatusbar) return
 

--- a/app/src/main/java/info/plateaukao/einkbro/activity/BrowserActivity.kt
+++ b/app/src/main/java/info/plateaukao/einkbro/activity/BrowserActivity.kt
@@ -66,6 +66,7 @@ import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.isVisible
 import androidx.fragment.app.FragmentActivity
+import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
 import androidx.lifecycle.lifecycleScope
 import info.plateaukao.einkbro.R
 import info.plateaukao.einkbro.browser.AlbumController
@@ -193,6 +194,7 @@ open class BrowserActivity : FragmentActivity(), BrowserController {
 
 
     // Layouts
+    private lateinit var swipeRefreshLayout: SwipeRefreshLayout
     private lateinit var mainContentLayout: FrameLayout
     private lateinit var subContainer: RelativeLayout
 
@@ -355,8 +357,17 @@ open class BrowserActivity : FragmentActivity(), BrowserController {
 
         orientation = resources.configuration.orientation
 
+        swipeRefreshLayout = findViewById(R.id.swipe_refresh_layout)
         mainContentLayout = findViewById(R.id.main_content)
         subContainer = findViewById(R.id.sub_container)
+
+        swipeRefreshLayout.setOnRefreshListener {
+            if (currentAlbumController != null) {
+                ebWebView.reload()
+            } else {
+                swipeRefreshLayout.isRefreshing = false
+            }
+        }
         ViewUnit.updateAppbarPosition(binding)
         initLaunchers()
         initToolbar()
@@ -2290,6 +2301,7 @@ open class BrowserActivity : FragmentActivity(), BrowserController {
         } else { // web page loading complete
             updateRefresh(false)
             progressBar.visibility = GONE
+            swipeRefreshLayout.isRefreshing = false
 
             scrollChange()
 

--- a/app/src/main/java/info/plateaukao/einkbro/activity/DataListActivity.kt
+++ b/app/src/main/java/info/plateaukao/einkbro/activity/DataListActivity.kt
@@ -18,7 +18,7 @@ import androidx.compose.material.Text
 import androidx.compose.material.TopAppBar
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
-import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.runtime.Composable
@@ -68,7 +68,7 @@ class DataListActivity : ComponentActivity(), KoinComponent {
                                 IconButton(onClick = { finish() }) {
                                     Icon(
                                         tint = MaterialTheme.colors.onPrimary,
-                                        imageVector = Icons.Filled.ArrowBack,
+                                        imageVector = Icons.AutoMirrored.Filled.ArrowBack,
                                         contentDescription = stringResource(R.string.back)
                                     )
                                 }
@@ -111,6 +111,7 @@ class DataListActivity : ComponentActivity(), KoinComponent {
     }
 
     private fun getWhitelistType(): BaseWhiteListType =
+        @Suppress("DEPRECATION")
         when (intent.getSerializableExtra(TYPE) as WhiteListType) {
             WhiteListType.Adblock -> WhiteListTypeAdblock()
             WhiteListType.Javascript -> BaseWhiteListTypeJavascript()

--- a/app/src/main/java/info/plateaukao/einkbro/activity/DictActivity.kt
+++ b/app/src/main/java/info/plateaukao/einkbro/activity/DictActivity.kt
@@ -94,6 +94,7 @@ class DictActivity : AppCompatActivity() {
         finish()
     }
 
+    @Suppress("DEPRECATION")
     private fun hideStatusBar() {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
             val controller = window.insetsController

--- a/app/src/main/java/info/plateaukao/einkbro/activity/GptActionsActivity.kt
+++ b/app/src/main/java/info/plateaukao/einkbro/activity/GptActionsActivity.kt
@@ -36,7 +36,7 @@ import androidx.compose.material.TextFieldDefaults
 import androidx.compose.material.TopAppBar
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
-import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.KeyboardArrowDown
@@ -98,7 +98,7 @@ class GptActionsActivity : ComponentActivity() {
                                 IconButton(onClick = { finish() }) {
                                     Icon(
                                         tint = MaterialTheme.colors.onPrimary,
-                                        imageVector = Icons.Filled.ArrowBack,
+                                        imageVector = Icons.AutoMirrored.Filled.ArrowBack,
                                         contentDescription = stringResource(R.string.back)
                                     )
                                 }

--- a/app/src/main/java/info/plateaukao/einkbro/activity/SettingActivity.kt
+++ b/app/src/main/java/info/plateaukao/einkbro/activity/SettingActivity.kt
@@ -21,7 +21,7 @@ import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
 import androidx.compose.material.TopAppBar
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.ExperimentalComposeUiApi
@@ -268,6 +268,7 @@ class SettingActivity : FragmentActivity() {
     override fun onResume() {
         super.onResume()
 
+        @Suppress("DEPRECATION")
         overridePendingTransition(0, 0)
     }
 
@@ -307,6 +308,7 @@ class SettingActivity : FragmentActivity() {
             }
         )
         finish()
+        @Suppress("DEPRECATION")
         overridePendingTransition(0, 0)
     }
 
@@ -1163,6 +1165,7 @@ class SettingActivity : FragmentActivity() {
         backupUnit.handleBookmarkSync(forceUpload)
     }
 
+    @Suppress("DEPRECATION")
     private fun hideStatusBar() {
         window.addFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN)
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
@@ -1217,7 +1220,7 @@ fun SettingBar(
             IconButton(onClick = navigateUp) {
                 Icon(
                     tint = MaterialTheme.colors.onPrimary,
-                    imageVector = Icons.Filled.ArrowBack,
+                    imageVector = Icons.AutoMirrored.Filled.ArrowBack,
                     contentDescription = stringResource(R.string.back)
                 )
             }

--- a/app/src/main/java/info/plateaukao/einkbro/activity/ToolbarConfigActivity.kt
+++ b/app/src/main/java/info/plateaukao/einkbro/activity/ToolbarConfigActivity.kt
@@ -105,6 +105,7 @@ class ToolbarConfigActivity : ComponentActivity() {
             window.setDecorFitsSystemWindows(false)
             window.insetsController?.hide(WindowInsets.Type.statusBars())
         } else {
+            @Suppress("DEPRECATION")
             window.clearFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN)
         }
     }

--- a/app/src/main/java/info/plateaukao/einkbro/browser/EBClickHandler.kt
+++ b/app/src/main/java/info/plateaukao/einkbro/browser/EBClickHandler.kt
@@ -1,11 +1,12 @@
 package info.plateaukao.einkbro.browser
 
 import android.os.Handler
+import android.os.Looper
 import android.os.Message
 import android.view.MotionEvent
 import info.plateaukao.einkbro.view.EBWebView
 
-class EBClickHandler(private val webView: EBWebView) : Handler() {
+class EBClickHandler(private val webView: EBWebView) : Handler(Looper.getMainLooper()) {
 
     var currentMotionEvent: MotionEvent? = null
 

--- a/app/src/main/java/info/plateaukao/einkbro/browser/EBWebChromeClient.kt
+++ b/app/src/main/java/info/plateaukao/einkbro/browser/EBWebChromeClient.kt
@@ -82,6 +82,7 @@ class EBWebChromeClient(
         return url.contains("facebook") && !url.contains("story") && !url.contains("l.php")
     }
 
+    @Suppress("DEPRECATION")
     private fun initWebView(webView: WebView) {
         val webSettings = webView.settings
         val defaultUserAgent = webSettings.userAgentString

--- a/app/src/main/java/info/plateaukao/einkbro/browser/NinjaWebViewClient.kt
+++ b/app/src/main/java/info/plateaukao/einkbro/browser/NinjaWebViewClient.kt
@@ -241,6 +241,7 @@ class EBWebViewClient(
     }
 
     @Deprecated("Deprecated in Java")
+    @Suppress("DEPRECATION")
     override fun shouldInterceptRequest(view: WebView, url: String): WebResourceResponse? =
         handleWebRequest(view, Uri.parse(url)) ?: super.shouldInterceptRequest(view, url)
 

--- a/app/src/main/java/info/plateaukao/einkbro/database/BookmarkDao.kt
+++ b/app/src/main/java/info/plateaukao/einkbro/database/BookmarkDao.kt
@@ -18,6 +18,7 @@ import androidx.sqlite.db.SupportSQLiteDatabase
 import info.plateaukao.einkbro.BuildConfig
 import info.plateaukao.einkbro.preference.ConfigManager
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.launch
@@ -168,6 +169,7 @@ interface BookmarkDao {
     }
 }
 
+@OptIn(DelicateCoroutinesApi::class)
 class BookmarkManager(context: Context) : KoinComponent {
     val config: ConfigManager by inject()
 

--- a/app/src/main/java/info/plateaukao/einkbro/database/RecordDb.kt
+++ b/app/src/main/java/info/plateaukao/einkbro/database/RecordDb.kt
@@ -39,8 +39,8 @@ class RecordDb(
     }
 
     private fun internalAddHistory(record: Record) {
-        if (record.title == null || record.title.trim { it <= ' ' }.isEmpty()
-            || record.url == null || record.url.trim { it <= ' ' }.isEmpty()
+        if (record.title.isNullOrBlank()
+            || record.url.isBlank()
             || record.time < 0L
         ) {
             return

--- a/app/src/main/java/info/plateaukao/einkbro/epub/EpubParser.kt
+++ b/app/src/main/java/info/plateaukao/einkbro/epub/EpubParser.kt
@@ -325,8 +325,8 @@ suspend fun epubParser(
         // write file to temp location with relative path
         val relativePath = file.absPath.substringAfter("$rootPath/")
         val epubFile = File(epubTempExtractionLocation + File.separator + relativePath)
-        if (!epubFile.parentFile.exists()) {
-            epubFile.parentFile.mkdirs()
+        if (epubFile.parentFile?.exists() != true) {
+            epubFile.parentFile?.mkdirs()
         }
         epubFile.writeBytes(file.data)
     }

--- a/app/src/main/java/info/plateaukao/einkbro/service/TranslateRepository.kt
+++ b/app/src/main/java/info/plateaukao/einkbro/service/TranslateRepository.kt
@@ -107,10 +107,8 @@ class TranslateRepository : KoinComponent {
         }
 
         val body =
-            RequestBody.create(
-                "application/json; charset=utf-8".toMediaTypeOrNull(),
-                processPostData(data, id)
-            )
+            processPostData(data, id)
+                .toRequestBody("application/json; charset=utf-8".toMediaTypeOrNull())
 
         val request = Request.Builder()
             .url("https://www2.deepl.com/jsonrpc")

--- a/app/src/main/java/info/plateaukao/einkbro/service/TtsManager.kt
+++ b/app/src/main/java/info/plateaukao/einkbro/service/TtsManager.kt
@@ -6,6 +6,7 @@ import android.speech.tts.UtteranceProgressListener
 import android.util.Log
 import info.plateaukao.einkbro.preference.ConfigManager
 import info.plateaukao.einkbro.unit.processedTextToChunks
+import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -15,6 +16,7 @@ import java.util.Locale
 import kotlin.coroutines.resume
 import kotlin.coroutines.suspendCoroutine
 
+@OptIn(DelicateCoroutinesApi::class)
 class TtsManager(
     private val context: Context,
 ) : KoinComponent {

--- a/app/src/main/java/info/plateaukao/einkbro/setting/SettingComposeUi.kt
+++ b/app/src/main/java/info/plateaukao/einkbro/setting/SettingComposeUi.kt
@@ -220,11 +220,13 @@ fun <T> ValueSettingItemUi(
                 setting.summaryResId,
                 setting.config.get()
             ) ?: return@launch
+            @Suppress("UNCHECKED_CAST")
             if (setting.config.get() is Int) {
                 setting.config.set(value.toInt() as T)
             } else {
                 setting.config.set(value as T)
             }
+            @Suppress("UNCHECKED_CAST")
             currentValue.value = value as T
         }
     }

--- a/app/src/main/java/info/plateaukao/einkbro/unit/BackupUnit.kt
+++ b/app/src/main/java/info/plateaukao/einkbro/unit/BackupUnit.kt
@@ -18,6 +18,7 @@ import info.plateaukao.einkbro.preference.ConfigManager
 import info.plateaukao.einkbro.view.EBToast
 import info.plateaukao.einkbro.view.dialog.DialogManager
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -37,6 +38,7 @@ import java.util.zip.ZipInputStream
 import java.util.zip.ZipOutputStream
 
 
+@OptIn(DelicateCoroutinesApi::class)
 class BackupUnit(
     private val context: Context,
 ) : KoinComponent {
@@ -180,7 +182,7 @@ class BackupUnit(
     private fun dlElement(elements: Elements, parentId: Int): List<Bookmark> {
         val bookmarkList = mutableListOf<Bookmark>()
         for (elem in elements) {
-            when (elem.nodeName().toUpperCase()) {
+            when (elem.nodeName().uppercase()) {
                 "DT" -> bookmarkList.addAll(dtElement(elem.children(), parentId))
                 "DL" -> bookmarkList.addAll(dlElement(elem.children(), parentId))
                 "P" -> continue
@@ -194,7 +196,7 @@ class BackupUnit(
     private fun dtElement(elements: Elements, parentId: Int): List<Bookmark> {
         val bookmarkList = mutableListOf<Bookmark>()
         for (elem in elements) {
-            when (elem.nodeName().toUpperCase()) {
+            when (elem.nodeName().uppercase()) {
                 "H3" -> {
                     currentFolderId = ++recordId
                     bookmarkList.add(

--- a/app/src/main/java/info/plateaukao/einkbro/unit/BrowserUnit.kt
+++ b/app/src/main/java/info/plateaukao/einkbro/unit/BrowserUnit.kt
@@ -50,6 +50,7 @@ import info.plateaukao.einkbro.view.dialog.DialogManager
 import info.plateaukao.einkbro.view.dialog.ShortcutEditDialog
 import info.plateaukao.einkbro.view.dialog.TextInputDialog
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -71,6 +72,7 @@ import java.util.Objects
 import java.util.regex.Pattern
 import kotlin.system.exitProcess
 
+@OptIn(DelicateCoroutinesApi::class)
 object BrowserUnit : KoinComponent {
     const val PROGRESS_MAX = 100
     const val SUFFIX_PNG = ".png"
@@ -164,6 +166,7 @@ object BrowserUnit : KoinComponent {
         return hitTestResult.extra ?: message.data.getString("src").orEmpty()
     }
 
+    @Suppress("DEPRECATION")
     fun getWebViewLinkUrl(webView: WebView, message: Message): String {
         val hitTestResult = webView.hitTestResult
 
@@ -248,7 +251,7 @@ object BrowserUnit : KoinComponent {
     @JvmStatic
     fun isURL(url: String?): Boolean {
         var url = url ?: return false
-        url = url.toLowerCase(Locale.getDefault())
+        url = url.lowercase(Locale.getDefault())
         if (url.startsWith(URL_ABOUT_BLANK)
             || url.startsWith(URL_SCHEME_MAIL_TO)
             || url.startsWith(URL_SCHEME_FILE)
@@ -280,7 +283,7 @@ object BrowserUnit : KoinComponent {
     fun queryWrapper(context: Context, query: String): String {
         // Use prefix and suffix to process some special links
         var query = query
-        val temp = query.toLowerCase(Locale.getDefault())
+        val temp = query.lowercase(Locale.getDefault())
         if (temp.contains(URL_PREFIX_GOOGLE_PLAY) && temp.contains(URL_SUFFIX_GOOGLE_PLAY)) {
             val start = temp.indexOf(URL_PREFIX_GOOGLE_PLAY) + URL_PREFIX_GOOGLE_PLAY.length
             val end = temp.indexOf(URL_SUFFIX_GOOGLE_PLAY)
@@ -453,9 +456,9 @@ object BrowserUnit : KoinComponent {
 
     fun guessFilename(url: String, contentDisposition: String, mimeType: String): String {
         val prefix = "filename*=utf-8''"
-        val decodedContentDescription = URLDecoder.decode(contentDisposition)
-        if (decodedContentDescription.toLowerCase().contains(prefix)) {
-            val index = decodedContentDescription.toLowerCase().indexOf(prefix)
+        val decodedContentDescription = URLDecoder.decode(contentDisposition, "UTF-8")
+        if (decodedContentDescription.lowercase().contains(prefix)) {
+            val index = decodedContentDescription.lowercase().indexOf(prefix)
             return decodedContentDescription.substring(index + prefix.length)
         }
         val anotherPrefix = "filename=\""
@@ -575,7 +578,7 @@ object BrowserUnit : KoinComponent {
         val takeFlags: Int = Intent.FLAG_GRANT_READ_URI_PERMISSION
         context.contentResolver?.takePersistableUriPermission(uri, takeFlags)
 
-        val file = File(uri.path)
+        val file = File(uri.path ?: return)
         if (isReaderMode) {
             config.readerCustomFontInfo = CustomFontInfo(file.name, uri.toString())
         } else {
@@ -773,6 +776,7 @@ object BrowserUnit : KoinComponent {
     fun restartApp(activity: Activity) {
         finishAffinity(activity) // Finishes all activities.
         activity.startActivity(activity.packageManager.getLaunchIntentForPackage(activity.packageName))    // Start the launch activity
+        @Suppress("DEPRECATION")
         activity.overridePendingTransition(0, 0)
         exitProcess(0)
     }

--- a/app/src/main/java/info/plateaukao/einkbro/unit/HelperUnit.kt
+++ b/app/src/main/java/info/plateaukao/einkbro/unit/HelperUnit.kt
@@ -139,7 +139,7 @@ object HelperUnit {
     fun setBottomSheetBehavior(dialog: BottomSheetDialog, view: View, beh: Int) {
         val mBehavior: BottomSheetBehavior<*> = BottomSheetBehavior.from(view.parent as View)
         mBehavior.state = beh
-        mBehavior.setBottomSheetCallback(object : BottomSheetCallback() {
+        mBehavior.addBottomSheetCallback(object : BottomSheetCallback() {
             override fun onStateChanged(bottomSheet: View, newState: Int) {
                 if (newState == BottomSheetBehavior.STATE_HIDDEN) {
                     dialog.cancel()
@@ -190,7 +190,7 @@ object HelperUnit {
         val originalUri = Uri.parse(url)
         val scheme = when (originalUri.scheme) {
             "https" -> "einkbros"
-            "https" -> "einkbro"
+            "http" -> "einkbro"
             else -> originalUri.scheme
         }
         return originalUri.buildUpon().scheme(scheme).build()
@@ -539,14 +539,19 @@ object HelperUnit {
         zipInputStream.close()
     }
 
+    @Suppress("DEPRECATION")
     private fun isAppInstalledFromPlayStore(context: Context): Boolean {
         val packageName = context.packageName
         val pm = context.packageManager
 
         return try {
-            val installerPackageName = pm.getInstallerPackageName(packageName)
+            val installerPackageName = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                pm.getInstallSourceInfo(packageName).installingPackageName
+            } else {
+                pm.getInstallerPackageName(packageName)
+            }
             "com.android.vending" == installerPackageName
-        } catch (e: IllegalArgumentException) {
+        } catch (e: Exception) {
             false
         }
     }

--- a/app/src/main/java/info/plateaukao/einkbro/unit/ViewUnit.kt
+++ b/app/src/main/java/info/plateaukao/einkbro/unit/ViewUnit.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.content.res.Configuration
 import android.content.res.Resources
 import android.graphics.Bitmap
+import androidx.core.view.drawToBitmap
 import android.graphics.Canvas
 import android.graphics.Color
 import android.graphics.ColorMatrix
@@ -60,14 +61,7 @@ object ViewUnit: KoinComponent {
     }
 
     fun captureDrawingCache(view: View): Bitmap {
-        view.isDrawingCacheEnabled = true
-        view.destroyDrawingCache()
-        view.buildDrawingCache()
-        var bitmap: Bitmap? = null
-        while (bitmap == null) {
-            bitmap = view.drawingCache
-        }
-        return bitmap
+        return view.drawToBitmap()
     }
 
     @JvmStatic
@@ -150,6 +144,7 @@ object ViewUnit: KoinComponent {
     }
 
     private var isNavigationBarDisplayed: Boolean? = null
+    @Suppress("DEPRECATION")
     fun setCustomFullscreen(
         window: Window,
         fullscreen: Boolean,
@@ -194,12 +189,8 @@ object ViewUnit: KoinComponent {
         val imm =
             activity.getSystemService(AppCompatActivity.INPUT_METHOD_SERVICE) as InputMethodManager
         activity.runOnUiThread {
-            imm.toggleSoftInput(
-                InputMethodManager.SHOW_FORCED,
-                InputMethodManager.HIDE_IMPLICIT_ONLY
-            )
-            //val view = activity.currentFocus ?: return@runOnUiThread
-            //imm.showSoftInput(view, 0)
+            val view = activity.currentFocus ?: return@runOnUiThread
+            imm.showSoftInput(view, InputMethodManager.SHOW_IMPLICIT)
         }
     }
 

--- a/app/src/main/java/info/plateaukao/einkbro/view/EBWebView.kt
+++ b/app/src/main/java/info/plateaukao/einkbro/view/EBWebView.kt
@@ -49,6 +49,7 @@ import info.plateaukao.einkbro.unit.HelperUnit.loadAssetFile
 import info.plateaukao.einkbro.unit.ViewUnit.dp
 import info.plateaukao.einkbro.util.PdfDocumentAdapter
 import info.plateaukao.einkbro.viewmodel.TRANSLATE_API
+import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import org.koin.core.component.KoinComponent
@@ -63,6 +64,7 @@ import kotlin.math.max
 import kotlin.math.min
 
 
+@OptIn(DelicateCoroutinesApi::class)
 open class EBWebView(
     context: Context,
     var browserController: BrowserController?,
@@ -208,6 +210,7 @@ open class EBWebView(
         addJavascriptInterface(JsWebInterface(this), "androidApp")
     }
 
+    @Suppress("DEPRECATION")
     private fun updateDarkMode() {
         if (config.darkMode == DarkMode.DISABLED) {
             return

--- a/app/src/main/java/info/plateaukao/einkbro/view/SwipeTouchListener.kt
+++ b/app/src/main/java/info/plateaukao/einkbro/view/SwipeTouchListener.kt
@@ -19,11 +19,11 @@ open class SwipeTouchListener(ctx: Context?) : OnTouchListener {
     @SuppressLint("ClickableViewAccessibility")
     override fun onTouch(v: View, event: MotionEvent): Boolean = gestureDetector.onTouchEvent(event)
 
-    @Suppress("NOTHING_TO_OVERRIDE", "ACCIDENTAL_OVERRIDE")
     private inner class GestureListener : SimpleOnGestureListener() {
         override fun onDown(e: MotionEvent): Boolean = false
 
-        override fun onFling(e1: MotionEvent, e2: MotionEvent, velocityX: Float, velocityY: Float): Boolean {
+        override fun onFling(e1: MotionEvent?, e2: MotionEvent, velocityX: Float, velocityY: Float): Boolean {
+            if (e1 == null) return false
             var result = false
             try {
                 val diffY = e2.y - e1.y

--- a/app/src/main/java/info/plateaukao/einkbro/view/dialog/DialogManager.kt
+++ b/app/src/main/java/info/plateaukao/einkbro/view/dialog/DialogManager.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package info.plateaukao.einkbro.view.dialog
 
 import android.app.Activity
@@ -34,6 +36,7 @@ class DialogManager(
     private val config: ConfigManager by inject()
     private val inflater = LayoutInflater.from(activity)
 
+    @Suppress("DEPRECATION")
     fun createProgressDialog(
         titleResId: Int,
     ): ProgressDialog = ProgressDialog(activity, R.style.TouchAreaDialog).apply {

--- a/app/src/main/java/info/plateaukao/einkbro/viewmodel/BookmarkViewModel.kt
+++ b/app/src/main/java/info/plateaukao/einkbro/viewmodel/BookmarkViewModel.kt
@@ -104,6 +104,7 @@ class BookmarkViewModel(private val bookmarkManager: BookmarkManager) : ViewMode
 
 class BookmarkViewModelFactory(private val bookmarkManager: BookmarkManager) :
     ViewModelProvider.NewInstanceFactory() {
+    @Suppress("UNCHECKED_CAST")
     override fun <T : ViewModel> create(modelClass: Class<T>): T =
         BookmarkViewModel(bookmarkManager) as T
 }

--- a/app/src/main/res/layout/activity_main_content.xml
+++ b/app/src/main/res/layout/activity_main_content.xml
@@ -6,15 +6,22 @@
     android:layout_height="match_parent"
     tools:showIn="@layout/activity_main">
 
-    <FrameLayout
-        android:id="@+id/main_content"
+    <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+        android:id="@+id/swipe_refresh_layout"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:background="?attr/backgroundColor"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintBottom_toBottomOf="parent" />
+        app:layout_constraintBottom_toBottomOf="parent">
+
+        <FrameLayout
+            android:id="@+id/main_content"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:background="?attr/backgroundColor" />
+
+    </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
 
     <View
         android:id="@+id/touch_area_middle_left"


### PR DESCRIPTION
## Summary
- Wrap the main WebView container (`main_content`) with `SwipeRefreshLayout` to enable pull-to-refresh
- Pulling down when the WebView is at the top of the page triggers a page reload
- The refresh indicator automatically dismisses when page loading completes
- Normal scrolling behavior is preserved when not at the top of the page

## Test plan
- [x] Verified on emulator: pull down at top of page triggers reload
- [x] Verified on emulator: pull down mid-page scrolls normally without triggering refresh
- [x] Build succeeds with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)