### PR TITLE
Add Tampermonkey-style userscript engine

### DIFF
--- a/app/schemas/info.plateaukao.einkbro.database.AppDatabase/10.json
+++ b/app/schemas/info.plateaukao.einkbro.database.AppDatabase/10.json
@@ -1,0 +1,528 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 10,
+    "identityHash": "1e5dae9626224c0b15a66c028c4390cf",
+    "entities": [
+      {
+        "tableName": "bookmarks",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`title` TEXT NOT NULL, `url` TEXT NOT NULL, `isDirectory` INTEGER NOT NULL, `parent` INTEGER NOT NULL, `order` INTEGER NOT NULL, `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isDirectory",
+            "columnName": "isDirectory",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "parent",
+            "columnName": "parent",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "order",
+            "columnName": "order",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "favicons",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`domain` TEXT NOT NULL, `icon` BLOB, PRIMARY KEY(`domain`))",
+        "fields": [
+          {
+            "fieldPath": "domain",
+            "columnName": "domain",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "icon",
+            "columnName": "icon",
+            "affinity": "BLOB",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "domain"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "highlights",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`articleId` INTEGER NOT NULL, `content` TEXT NOT NULL, `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, FOREIGN KEY(`articleId`) REFERENCES `articles`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "articleId",
+            "columnName": "articleId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_highlights_articleId",
+            "unique": false,
+            "columnNames": [
+              "articleId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_highlights_articleId` ON `${TABLE_NAME}` (`articleId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "articles",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "articleId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "articles",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`title` TEXT NOT NULL, `url` TEXT NOT NULL, `date` INTEGER NOT NULL, `tags` TEXT NOT NULL, `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "date",
+            "columnName": "date",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tags",
+            "columnName": "tags",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "chat_gpt_query",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`date` INTEGER NOT NULL, `url` TEXT NOT NULL, `model` TEXT NOT NULL, `selectedText` TEXT NOT NULL, `result` TEXT NOT NULL, `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "date",
+            "columnName": "date",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "model",
+            "columnName": "model",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "selectedText",
+            "columnName": "selectedText",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "result",
+            "columnName": "result",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "domain_configuration",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`domain` TEXT NOT NULL, `configuration` TEXT NOT NULL, PRIMARY KEY(`domain`))",
+        "fields": [
+          {
+            "fieldPath": "domain",
+            "columnName": "domain",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "configuration",
+            "columnName": "configuration",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "domain"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "translation_cache",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`originalText` TEXT NOT NULL, `targetLanguage` TEXT NOT NULL, `translatedText` TEXT NOT NULL, `timestamp` INTEGER NOT NULL, PRIMARY KEY(`originalText`, `targetLanguage`))",
+        "fields": [
+          {
+            "fieldPath": "originalText",
+            "columnName": "originalText",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "targetLanguage",
+            "columnName": "targetLanguage",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "translatedText",
+            "columnName": "translatedText",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "originalText",
+            "targetLanguage"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "saved_pages",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`title` TEXT NOT NULL, `url` TEXT NOT NULL, `filePath` TEXT NOT NULL, `savedAt` INTEGER NOT NULL, `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "filePath",
+            "columnName": "filePath",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "savedAt",
+            "columnName": "savedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "HISTORY",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`TITLE` TEXT NOT NULL, `URL` TEXT NOT NULL, `TIME` INTEGER NOT NULL, `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "TITLE",
+            "columnName": "TITLE",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "URL",
+            "columnName": "URL",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "TIME",
+            "columnName": "TIME",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "WHITELIST",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`DOMAIN` TEXT NOT NULL, PRIMARY KEY(`DOMAIN`))",
+        "fields": [
+          {
+            "fieldPath": "DOMAIN",
+            "columnName": "DOMAIN",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "DOMAIN"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "JAVASCRIPT",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`DOMAIN` TEXT NOT NULL, PRIMARY KEY(`DOMAIN`))",
+        "fields": [
+          {
+            "fieldPath": "DOMAIN",
+            "columnName": "DOMAIN",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "DOMAIN"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "COOKIE",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`DOMAIN` TEXT NOT NULL, PRIMARY KEY(`DOMAIN`))",
+        "fields": [
+          {
+            "fieldPath": "DOMAIN",
+            "columnName": "DOMAIN",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "DOMAIN"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "user_scripts",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `enabled` INTEGER NOT NULL, `code` TEXT NOT NULL, `sourceUrl` TEXT, `order` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "enabled",
+            "columnName": "enabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "code",
+            "columnName": "code",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceUrl",
+            "columnName": "sourceUrl",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "order",
+            "columnName": "order",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "user_script_values",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`scriptId` INTEGER NOT NULL, `key` TEXT NOT NULL, `value` TEXT NOT NULL, PRIMARY KEY(`scriptId`, `key`))",
+        "fields": [
+          {
+            "fieldPath": "scriptId",
+            "columnName": "scriptId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "key",
+            "columnName": "key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "value",
+            "columnName": "value",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "scriptId",
+            "key"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '1e5dae9626224c0b15a66c028c4390cf')"
+    ]
+  }
+}

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -241,6 +241,9 @@
         <activity
             android:name=".activity.SavedPagesActivity"
             android:exported="false" />
+        <activity
+            android:name=".activity.UserScriptListActivity"
+            android:exported="false" />
 
         <receiver
             android:name=".service.TtsNotificationReceiver"

--- a/app/src/main/assets/gm_shim.js
+++ b/app/src/main/assets/gm_shim.js
@@ -1,0 +1,270 @@
+// EinkBro userscript GM API shim.
+// Templated per-script: __SCRIPT_ID__ and __GM_INFO__ are substituted at inject time.
+// Defines GM_* and the promisified GM.* on the page's window so userscripts can use them.
+
+// Some Android System WebView builds don't expose `globalThis` in the injected script
+// scope, which breaks modern bundles (e.g. Immersive Translate). Polyfill it first.
+if (typeof globalThis === 'undefined') {
+    try {
+        (typeof self !== 'undefined' ? self : window).globalThis =
+            (typeof self !== 'undefined' ? self : window);
+    } catch (e) {}
+}
+
+// Scripts that route all network through GM_xmlhttpRequest (Immersive Translate deletes
+// window.fetch to bypass CORS) wrap each response in `new Response(body, {status})`.
+// Null-body statuses (204/205/304) make that throw "Response with null body status
+// cannot have body"; subclass so those statuses drop the body.
+(function () {
+    var Orig = window.Response;
+    if (!Orig) return;
+    try {
+        window.Response = class extends Orig {
+            constructor(body, init) {
+                init = init || {};
+                var s = init.status;
+                if (body != null && (s === 204 || s === 205 || s === 304)) super(null, init);
+                else super(body, init);
+            }
+        };
+    } catch (e) { /* keep native Response if subclassing unsupported */ }
+})();
+
+(function () {
+    var SCRIPT_ID = __SCRIPT_ID__;
+    var GM_INFO = __GM_INFO__;
+
+    // Shared per-page registry, keyed by script id, on a single hidden global.
+    var hub = window.__einkbroGM;
+    if (!hub) {
+        hub = window.__einkbroGM = {
+            xhrCallbacks: {},
+            menuCallbacks: {},
+            seq: 0,
+            handleXhr: function (reqId, eventName, payload) {
+                var self = this;
+                // Dispatch asynchronously (macrotask). The native bridge delivers this
+                // synchronously via evaluateJavascript, which can run inside the same JS
+                // turn as a script's `new Promise(executor)` that called GM_xmlhttpRequest.
+                // Resolving that promise synchronously from within its own executor leaves
+                // it permanently pending in this WebView's V8 — so defer by a turn.
+                setTimeout(function () {
+                    var cb = self.xhrCallbacks[reqId];
+                    if (!cb) return;
+                    var resp;
+                    try { resp = JSON.parse(payload); } catch (e) { resp = {}; }
+                    if (cb.responseType === 'json' && typeof resp.responseText === 'string') {
+                        try { resp.response = JSON.parse(resp.responseText); } catch (e2) {}
+                    }
+                    try {
+                        if (eventName === 'progress') {
+                            if (cb.onprogress) cb.onprogress(resp);
+                        } else if (eventName === 'error') {
+                            if (cb.onerror) cb.onerror(resp);
+                        } else if (eventName === 'timeout') {
+                            if (cb.ontimeout) cb.ontimeout(resp);
+                            else if (cb.onerror) cb.onerror(resp);
+                        } else if (eventName === 'load') {
+                            // Tampermonkey order: onreadystatechange(readyState 4) then onload.
+                            resp.readyState = 4;
+                            if (cb.onreadystatechange) cb.onreadystatechange(resp);
+                            if (cb.onload) cb.onload(resp);
+                        }
+                    } catch (cbErr) {
+                        console.error('einkbro GM_xhr callback error', cbErr);
+                    }
+                    if (eventName === 'load' || eventName === 'error' || eventName === 'timeout') {
+                        delete self.xhrCallbacks[reqId];
+                    }
+                }, 0);
+            },
+            invokeMenu: function (fnId) {
+                var cb = this.menuCallbacks[fnId];
+                if (cb) cb();
+            }
+        };
+    }
+
+    var bridge = window.einkbroGM;
+
+    function GM_getValue(key, defaultValue) {
+        try {
+            var raw = bridge.gmGetValue(SCRIPT_ID, key);
+            if (raw === null || raw === undefined) return defaultValue;
+            return JSON.parse(raw);
+        } catch (e) {
+            return defaultValue;
+        }
+    }
+
+    function GM_setValue(key, value) {
+        bridge.gmSetValue(SCRIPT_ID, key, JSON.stringify(value));
+    }
+
+    function GM_deleteValue(key) {
+        bridge.gmDeleteValue(SCRIPT_ID, key);
+    }
+
+    function GM_listValues() {
+        try {
+            return JSON.parse(bridge.gmListValues(SCRIPT_ID) || '[]');
+        } catch (e) {
+            return [];
+        }
+    }
+
+    function GM_addStyle(css) {
+        var style = document.createElement('style');
+        style.textContent = css;
+        (document.head || document.documentElement).appendChild(style);
+        return style;
+    }
+
+    function GM_addElement(parentOrTag, tagOrAttrs, maybeAttrs) {
+        var parent, tag, attrs;
+        if (typeof parentOrTag === 'string') {
+            parent = null; tag = parentOrTag; attrs = tagOrAttrs || {};
+        } else {
+            parent = parentOrTag; tag = tagOrAttrs; attrs = maybeAttrs || {};
+        }
+        var el = document.createElement(tag);
+        for (var k in attrs) {
+            if (!attrs.hasOwnProperty(k)) continue;
+            if (k === 'textContent') el.textContent = attrs[k];
+            else el.setAttribute(k, attrs[k]);
+        }
+        (parent || document.head || document.documentElement).appendChild(el);
+        return el;
+    }
+
+    function GM_xmlhttpRequest(details) {
+        var reqId = SCRIPT_ID + ':' + (++hub.seq);
+        hub.xhrCallbacks[reqId] = {
+            onload: details.onload,
+            onerror: details.onerror,
+            ontimeout: details.ontimeout,
+            onprogress: details.onprogress,
+            onreadystatechange: details.onreadystatechange,
+            responseType: details.responseType || ''
+        };
+        var wire = {
+            method: details.method || 'GET',
+            url: details.url,
+            headers: details.headers || {},
+            data: details.data != null ? details.data : null,
+            responseType: details.responseType || '',
+            timeout: details.timeout || 0,
+            user: details.user || null,
+            password: details.password || null
+        };
+        try {
+            bridge.gmXhr(SCRIPT_ID, reqId, JSON.stringify(wire));
+        } catch (e) {
+            delete hub.xhrCallbacks[reqId];
+            if (details.onerror) details.onerror({ error: String(e) });
+        }
+        return {
+            abort: function () { try { bridge.gmAbortXhr(reqId); } catch (e) {} }
+        };
+    }
+
+    function GM_registerMenuCommand(caption, fn) {
+        var fnId = SCRIPT_ID + ':menu:' + (++hub.seq);
+        hub.menuCallbacks[fnId] = fn;
+        try { bridge.gmRegisterMenuCommand(SCRIPT_ID, String(caption), fnId); } catch (e) {}
+        return fnId;
+    }
+
+    function GM_unregisterMenuCommand(fnId) {
+        delete hub.menuCallbacks[fnId];
+        try { bridge.gmUnregisterMenuCommand(fnId); } catch (e) {}
+    }
+
+    function GM_openInTab(url, options) {
+        var active = true;
+        if (typeof options === 'boolean') active = !options; // legacy: openInBackground
+        else if (options && typeof options === 'object') active = options.active !== false;
+        try { bridge.gmOpenInTab(url, active); } catch (e) {}
+        return { closed: false, close: function () {} };
+    }
+
+    function GM_setClipboard(text) {
+        try { bridge.gmSetClipboard(String(text)); } catch (e) {}
+    }
+
+    function GM_log() {
+        try { bridge.gmLog(Array.prototype.join.call(arguments, ' ')); } catch (e) {}
+    }
+
+    function GM_notification(textOrDetails) {
+        var text = typeof textOrDetails === 'object' ? textOrDetails.text : textOrDetails;
+        try { bridge.gmNotification(String(text)); } catch (e) {}
+    }
+
+    function promisify(fn) {
+        return function () {
+            var args = arguments;
+            return new Promise(function (resolve, reject) {
+                try { resolve(fn.apply(null, args)); } catch (e) { reject(e); }
+            });
+        };
+    }
+
+    // GM.xmlHttpRequest must support BOTH styles, exactly like Tampermonkey:
+    //  - callback style: caller passes details.onload/onerror; we fire those and return a
+    //    control object. Immersive Translate's GM_fetch polyfill uses THIS style.
+    //  - promise style: when no onload is given, return a thenable resolving to the response.
+    // Implementing only the promise form silently swallows callback-style callers, leaving
+    // their wrapping promise pending forever.
+    function GM_xmlhttpRequestDual(details) {
+        details = details || {};
+        if (details.onload || details.onerror || details.onreadystatechange) {
+            return GM_xmlhttpRequest(details); // callback style
+        }
+        // promise style — wire resolve/reject as the callbacks
+        return new Promise(function (resolve, reject) {
+            var d = {};
+            for (var k in details) d[k] = details[k];
+            d.onload = resolve;
+            d.onerror = reject;
+            d.ontimeout = reject;
+            GM_xmlhttpRequest(d);
+        });
+    }
+
+    // Expose globals on window (main world).
+    var w = window;
+    w.GM_getValue = GM_getValue;
+    w.GM_setValue = GM_setValue;
+    w.GM_deleteValue = GM_deleteValue;
+    w.GM_listValues = GM_listValues;
+    w.GM_addStyle = GM_addStyle;
+    w.GM_addElement = GM_addElement;
+    w.GM_xmlhttpRequest = GM_xmlhttpRequest;
+    w.GM_registerMenuCommand = GM_registerMenuCommand;
+    w.GM_unregisterMenuCommand = GM_unregisterMenuCommand;
+    w.GM_openInTab = GM_openInTab;
+    w.GM_setClipboard = GM_setClipboard;
+    w.GM_log = GM_log;
+    w.GM_notification = GM_notification;
+    w.GM_info = GM_INFO;
+    w.unsafeWindow = w;
+
+    w.GM = {
+        info: GM_INFO,
+        getValue: promisify(GM_getValue),
+        setValue: promisify(GM_setValue),
+        deleteValue: promisify(GM_deleteValue),
+        listValues: promisify(GM_listValues),
+        addStyle: promisify(GM_addStyle),
+        addElement: promisify(GM_addElement),
+        registerMenuCommand: GM_registerMenuCommand,
+        unregisterMenuCommand: GM_unregisterMenuCommand,
+        openInTab: GM_openInTab,
+        setClipboard: promisify(GM_setClipboard),
+        notification: promisify(GM_notification),
+        xmlHttpRequest: GM_xmlhttpRequestDual,
+        xmlhttpRequest: GM_xmlhttpRequestDual,
+        log: GM_log
+    };
+})();

--- a/app/src/main/assets/text_selection_change.js
+++ b/app/src/main/assets/text_selection_change.js
@@ -2,7 +2,7 @@
             function getSelectionPositionInWebView() {
     let selection = window.getSelection();
 
-    if (selection) {
+    if (selection && selection.rangeCount > 0) {
         let range = selection.getRangeAt(0);
         let startNode = range.startContainer;
         let startOffset = range.startOffset;

--- a/app/src/main/assets/text_selection_highlight.js
+++ b/app/src/main/assets/text_selection_highlight.js
@@ -1,5 +1,7 @@
  function highlightSelection() {
-  var userSelection = window.getSelection().getRangeAt(0);
+  var sel = window.getSelection();
+  if (!sel || sel.rangeCount === 0) return;
+  var userSelection = sel.getRangeAt(0);
   var safeRanges = getSafeRanges(userSelection);
   for (var i = 0; i < safeRanges.length; i++) {
     highlightRange(safeRanges[i]);

--- a/app/src/main/java/info/plateaukao/einkbro/EinkBroApplication.kt
+++ b/app/src/main/java/info/plateaukao/einkbro/EinkBroApplication.kt
@@ -71,6 +71,7 @@ class EinkBroApplication : Application() {
         single { config }
         single { sp }
         single { BookmarkManager(androidContext()) }
+        single { info.plateaukao.einkbro.userscript.UserScriptManager() }
         single { RecordRepository() }
         single { AdBlock(androidContext()) }
         single { Javascript(androidContext()) }

--- a/app/src/main/java/info/plateaukao/einkbro/EinkBroApplication.kt
+++ b/app/src/main/java/info/plateaukao/einkbro/EinkBroApplication.kt
@@ -71,7 +71,7 @@ class EinkBroApplication : Application() {
         single { config }
         single { sp }
         single { BookmarkManager(androidContext()) }
-        single { info.plateaukao.einkbro.userscript.UserScriptManager() }
+        single { info.plateaukao.einkbro.userscript.UserScriptManager(androidContext()) }
         single { RecordRepository() }
         single { AdBlock(androidContext()) }
         single { Javascript(androidContext()) }

--- a/app/src/main/java/info/plateaukao/einkbro/activity/SettingActivity.kt
+++ b/app/src/main/java/info/plateaukao/einkbro/activity/SettingActivity.kt
@@ -1353,6 +1353,11 @@ class SettingActivity : FragmentActivity() {
             0,
             R.string.setting_summary_whitelistJS,
         ) { startActivity(DataListActivity.createIntent(this, WhiteListType.Javascript)) },
+        ActionSettingItem(
+            R.string.setting_title_userscripts,
+            0,
+            R.string.setting_summary_userscripts,
+        ) { startActivity(UserScriptListActivity.createIntent(this)) },
         DividerSettingItem(),
         BooleanSettingItem(
             R.string.setting_title_cookie,

--- a/app/src/main/java/info/plateaukao/einkbro/activity/UserScriptListActivity.kt
+++ b/app/src/main/java/info/plateaukao/einkbro/activity/UserScriptListActivity.kt
@@ -1,0 +1,299 @@
+package info.plateaukao.einkbro.activity
+
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.Divider
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.OutlinedButton
+import androidx.compose.material.Scaffold
+import androidx.compose.material.Switch
+import androidx.compose.material.Text
+import androidx.compose.material.TextButton
+import androidx.compose.material.TextField
+import androidx.compose.material.TopAppBar
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.lifecycle.lifecycleScope
+import info.plateaukao.einkbro.R
+import info.plateaukao.einkbro.database.UserScript
+import info.plateaukao.einkbro.userscript.UserScriptManager
+import info.plateaukao.einkbro.view.compose.MyTheme
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import org.koin.android.ext.android.inject
+
+class UserScriptListActivity : ComponentActivity() {
+    private val userScriptManager: UserScriptManager by inject()
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        val initialCode = intent?.getStringExtra(EXTRA_CODE)
+        val initialSourceUrl = intent?.getStringExtra(EXTRA_SOURCE_URL)
+
+        setContent {
+            val scripts = remember { mutableStateListOf<UserScript>() }
+            var editing by remember { mutableStateOf<UserScript?>(null) }
+            var showEditor by remember { mutableStateOf(false) }
+            var editorSourceUrl by remember { mutableStateOf<String?>(null) }
+
+            fun refresh() {
+                lifecycleScope.launch {
+                    val list = withContext(Dispatchers.IO) {
+                        userScriptManager.reload()
+                        userScriptManager.scripts.map { it.script }
+                    }
+                    scripts.clear()
+                    scripts.addAll(list)
+                }
+            }
+
+            remember {
+                refresh()
+                // If launched with a script to install (from a .user.js URL), open the editor.
+                if (initialCode != null) {
+                    editing = UserScript(name = "", code = initialCode, sourceUrl = initialSourceUrl)
+                    editorSourceUrl = initialSourceUrl
+                    showEditor = true
+                }
+                true
+            }
+
+            MyTheme {
+                Scaffold(
+                    topBar = {
+                        TopAppBar(
+                            title = { Text(stringResource(R.string.setting_title_userscripts)) },
+                            navigationIcon = {
+                                IconButton(onClick = { finish() }) {
+                                    Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = null)
+                                }
+                            },
+                            actions = {
+                                IconButton(onClick = {
+                                    editing = null
+                                    editorSourceUrl = null
+                                    showEditor = true
+                                }) {
+                                    Icon(Icons.Filled.Add, contentDescription = stringResource(R.string.userscript_add))
+                                }
+                            },
+                        )
+                    },
+                ) { padding ->
+                    Column(modifier = Modifier.fillMaxSize().padding(padding)) {
+                        if (scripts.isEmpty()) {
+                            Text(
+                                stringResource(R.string.userscript_empty),
+                                modifier = Modifier.padding(24.dp),
+                                color = MaterialTheme.colors.onSurface,
+                            )
+                        }
+                        LazyColumn(modifier = Modifier.fillMaxSize()) {
+                            items(scripts, key = { it.id }) { script ->
+                                ScriptRow(
+                                    script = script,
+                                    onToggle = { enabled ->
+                                        lifecycleScope.launch {
+                                            withContext(Dispatchers.IO) {
+                                                userScriptManager.setEnabled(script.id, enabled)
+                                            }
+                                            refresh()
+                                        }
+                                    },
+                                    onEdit = {
+                                        editing = script
+                                        editorSourceUrl = script.sourceUrl
+                                        showEditor = true
+                                    },
+                                    onDelete = {
+                                        lifecycleScope.launch {
+                                            withContext(Dispatchers.IO) {
+                                                userScriptManager.delete(script.id)
+                                            }
+                                            refresh()
+                                        }
+                                    },
+                                )
+                                Divider()
+                            }
+                        }
+                    }
+                }
+
+                if (showEditor) {
+                    ScriptEditorDialog(
+                        initial = editing,
+                        onDismiss = { showEditor = false },
+                        onSaveCode = { code ->
+                            showEditor = false
+                            lifecycleScope.launch {
+                                withContext(Dispatchers.IO) {
+                                    val current = editing
+                                    if (current != null && current.id != 0L) {
+                                        userScriptManager.update(current.copy(code = code))
+                                    } else {
+                                        userScriptManager.add(code, editorSourceUrl)
+                                    }
+                                }
+                                refresh()
+                            }
+                        },
+                        onFetchUrl = { url, onResult ->
+                            lifecycleScope.launch {
+                                val fetched = withContext(Dispatchers.IO) { fetchScript(url) }
+                                if (fetched != null) {
+                                    editorSourceUrl = url
+                                    onResult(fetched)
+                                }
+                            }
+                        },
+                    )
+                }
+            }
+        }
+    }
+
+    private fun fetchScript(url: String): String? = try {
+        OkHttpClient().newCall(Request.Builder().url(url).build()).execute().use { resp ->
+            resp.body?.string()
+        }
+    } catch (e: Exception) {
+        null
+    }
+
+    companion object {
+        private const val EXTRA_CODE = "code"
+        private const val EXTRA_SOURCE_URL = "sourceUrl"
+
+        fun createIntent(context: Context, code: String? = null, sourceUrl: String? = null): Intent =
+            Intent(context, UserScriptListActivity::class.java).apply {
+                if (code != null) putExtra(EXTRA_CODE, code)
+                if (sourceUrl != null) putExtra(EXTRA_SOURCE_URL, sourceUrl)
+            }
+    }
+}
+
+@Composable
+private fun ScriptRow(
+    script: UserScript,
+    onToggle: (Boolean) -> Unit,
+    onEdit: () -> Unit,
+    onDelete: () -> Unit,
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth().padding(horizontal = 12.dp, vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Switch(checked = script.enabled, onCheckedChange = onToggle)
+        Spacer(Modifier.width(12.dp))
+        Text(
+            script.name.ifBlank { "(unnamed)" },
+            modifier = Modifier.weight(1f),
+            color = MaterialTheme.colors.onSurface,
+        )
+        IconButton(onClick = onEdit) {
+            Icon(Icons.Filled.Edit, contentDescription = stringResource(R.string.menu_edit))
+        }
+        IconButton(onClick = onDelete) {
+            Icon(Icons.Filled.Delete, contentDescription = stringResource(R.string.menu_delete))
+        }
+    }
+}
+
+@Composable
+private fun ScriptEditorDialog(
+    initial: UserScript?,
+    onDismiss: () -> Unit,
+    onSaveCode: (String) -> Unit,
+    onFetchUrl: (String, (String) -> Unit) -> Unit,
+) {
+    var code by remember { mutableStateOf(initial?.code.orEmpty()) }
+    var url by remember { mutableStateOf("") }
+
+    Dialog(onDismissRequest = onDismiss) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(MaterialTheme.colors.surface)
+                .padding(16.dp),
+        ) {
+            Text(
+                stringResource(R.string.setting_title_userscripts),
+                style = MaterialTheme.typography.h6,
+                color = MaterialTheme.colors.onSurface,
+                modifier = Modifier.padding(bottom = 12.dp),
+            )
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                TextField(
+                    value = url,
+                    onValueChange = { url = it },
+                    modifier = Modifier.weight(1f),
+                    singleLine = true,
+                    label = { Text(stringResource(R.string.userscript_install_from_url)) },
+                )
+                Spacer(Modifier.width(8.dp))
+                OutlinedButton(onClick = { if (url.isNotBlank()) onFetchUrl(url) { code = it } }) {
+                    Text(stringResource(R.string.userscript_fetch))
+                }
+            }
+            Spacer(Modifier.height(8.dp))
+            TextField(
+                value = code,
+                onValueChange = { code = it },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .heightIn(min = 200.dp, max = 360.dp),
+                label = { Text(stringResource(R.string.userscript_code)) },
+            )
+            Row(
+                modifier = Modifier.fillMaxWidth().padding(top = 12.dp),
+                horizontalArrangement = Arrangement.End,
+            ) {
+                TextButton(onClick = onDismiss) { Text(stringResource(android.R.string.cancel)) }
+                Spacer(Modifier.width(8.dp))
+                TextButton(onClick = { if (code.isNotBlank()) onSaveCode(code) }) {
+                    Text(stringResource(android.R.string.ok))
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/info/plateaukao/einkbro/browser/NinjaWebViewClient.kt
+++ b/app/src/main/java/info/plateaukao/einkbro/browser/NinjaWebViewClient.kt
@@ -43,6 +43,10 @@ import info.plateaukao.einkbro.view.EBWebView
 import info.plateaukao.einkbro.view.dialog.DialogManager
 import info.plateaukao.einkbro.view.dialog.compose.AuthenticationDialogFragment
 import io.github.edsuns.adfilter.AdFilter
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 import java.io.ByteArrayInputStream
@@ -68,6 +72,9 @@ class EBWebViewClient(
     private val dualCaptionProcessor = DualCaptionProcessor()
 
     private val einkImageCache = EinkImageCache(context)
+
+    private val userScriptManager: info.plateaukao.einkbro.userscript.UserScriptManager by inject()
+    private val coroutineScope: CoroutineScope by inject()
 
     fun enableAdBlock(enable: Boolean) {
         this.hasAdBlock = enable
@@ -118,6 +125,7 @@ class EBWebViewClient(
 
     override fun onPageStarted(view: WebView?, url: String?, favicon: Bitmap?) {
         super.onPageStarted(view, url, favicon)
+        ebWebView.currentPageUrl = url
         // resetState() in EBWebView already cleared dualCaption; let the next
         // doUpdateVisitedHistory treat this as a fresh start so it doesn't wipe the
         // caption captured during this page's load.
@@ -137,6 +145,38 @@ class EBWebViewClient(
         }
 
         url?.let { injectForcedViewportWidth(it) }
+
+        // userscripts are page-scoped; reset the per-page menu registry, then run
+        // any document-start scripts for this URL.
+        ebWebView.userScriptMenuCommands.clear()
+        url?.let { injectUserScripts(it, info.plateaukao.einkbro.userscript.RunAt.DOCUMENT_START) }
+    }
+
+    private fun injectUserScripts(url: String, runAt: info.plateaukao.einkbro.userscript.RunAt) {
+        val matching = userScriptManager.getMatchingScripts(url, runAt)
+        if (matching.isEmpty()) return
+        matching.forEach { parsed ->
+            // Inject as a same-origin <script> element rather than evaluateJavascript():
+            // eval'd code has no script origin, so Chromium sanitizes its async exceptions
+            // to opaque "Script error." and some scripts misbehave. A script tag runs the
+            // userscript exactly like a real userscript manager does. The body is passed as
+            // base64 to avoid escaping issues with large UTF-8 payloads.
+            val js = userScriptManager.buildInjectionJs(parsed)
+            val b64 = android.util.Base64.encodeToString(
+                js.toByteArray(Charsets.UTF_8), android.util.Base64.NO_WRAP,
+            )
+            val injector = """
+                (function(){
+                    try {
+                        var s = document.createElement('script');
+                        s.textContent = decodeURIComponent(escape(atob('$b64')));
+                        (document.head || document.documentElement).appendChild(s);
+                        s.parentNode && s.parentNode.removeChild(s);
+                    } catch(e) { console.error('einkbro userscript inject', e); }
+                })();
+            """.trimIndent()
+            ebWebView.evaluateJavascript(injector, null)
+        }
     }
 
     private fun injectForcedViewportWidth(url: String) {
@@ -148,6 +188,7 @@ class EBWebViewClient(
     }
 
     override fun onPageFinished(view: WebView, url: String) {
+        ebWebView.currentPageUrl = url
         ebWebView.updateCssStyle()
 
         // Re-inject autoplay blocker in onPageFinished to ensure it's in the correct page context
@@ -214,6 +255,34 @@ class EBWebViewClient(
                 ebWebView.evaluateJavascript(
                     "(function(){try{$userJs}catch(e){console.error('einkbro user js',e);}})();",
                     null,
+                )
+            }
+            injectUserScripts(url, info.plateaukao.einkbro.userscript.RunAt.DOCUMENT_END)
+        }
+    }
+
+    private fun isUserScriptUrl(url: String): Boolean {
+        val path = try {
+            Uri.parse(url).path?.lowercase().orEmpty()
+        } catch (e: Exception) {
+            ""
+        }
+        return path.endsWith(".user.js")
+    }
+
+    private fun offerUserScriptInstall(url: String) {
+        coroutineScope.launch(Dispatchers.IO) {
+            val code = try {
+                java.net.URL(url).openStream().bufferedReader().use { it.readText() }
+            } catch (e: Exception) {
+                Log.w("EBWebViewClient", "Failed to fetch userscript $url: ${e.message}")
+                null
+            } ?: return@launch
+            withContext(Dispatchers.Main) {
+                context.startActivity(
+                    info.plateaukao.einkbro.activity.UserScriptListActivity.createIntent(
+                        context, code, url,
+                    )
                 )
             }
         }

--- a/app/src/main/java/info/plateaukao/einkbro/browser/UserScriptBridge.kt
+++ b/app/src/main/java/info/plateaukao/einkbro/browser/UserScriptBridge.kt
@@ -1,0 +1,227 @@
+package info.plateaukao.einkbro.browser
+
+import android.content.ClipData
+import android.content.ClipboardManager
+import android.content.Context
+import android.net.Uri
+import android.util.Log
+import android.webkit.JavascriptInterface
+import android.widget.Toast
+import info.plateaukao.einkbro.userscript.UserScriptManager
+import info.plateaukao.einkbro.view.EBWebView
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import okhttp3.MediaType.Companion.toMediaTypeOrNull
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import org.json.JSONObject
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
+import java.net.URI
+import java.util.concurrent.TimeUnit
+
+/**
+ * Native side of the GM_* API. Registered on the WebView as `window.einkbroGM`.
+ * All @JavascriptInterface methods run on the WebView's private JS-bridge thread
+ * (never the main thread), so synchronous Room access here is safe.
+ */
+class UserScriptBridge(
+    private val webView: EBWebView,
+) : KoinComponent {
+    private val userScriptManager: UserScriptManager by inject()
+    private val coroutineScope: CoroutineScope by inject()
+    private val httpClient = OkHttpClient.Builder()
+        .connectTimeout(15, TimeUnit.SECONDS)
+        .readTimeout(30, TimeUnit.SECONDS)
+        .callTimeout(60, TimeUnit.SECONDS)
+        .retryOnConnectionFailure(true)
+        .build()
+
+    // region GM value storage (synchronous)
+
+    @JavascriptInterface
+    fun gmGetValue(scriptId: String, key: String): String? =
+        userScriptManager.gmGetValue(scriptId.toLong(), key)
+
+    @JavascriptInterface
+    fun gmSetValue(scriptId: String, key: String, value: String) =
+        userScriptManager.gmSetValue(scriptId.toLong(), key, value)
+
+    @JavascriptInterface
+    fun gmDeleteValue(scriptId: String, key: String) =
+        userScriptManager.gmDeleteValue(scriptId.toLong(), key)
+
+    @JavascriptInterface
+    fun gmListValues(scriptId: String): String {
+        val keys = userScriptManager.gmListValues(scriptId.toLong())
+        val arr = org.json.JSONArray()
+        keys.forEach { arr.put(it) }
+        return arr.toString()
+    }
+
+    // endregion
+
+    // region GM_xmlhttpRequest
+
+    @JavascriptInterface
+    fun gmXhr(scriptId: String, reqId: String, detailsJson: String) {
+        coroutineScope.launch(Dispatchers.IO) {
+            try {
+                val details = JSONObject(detailsJson)
+                val url = details.getString("url")
+
+                if (!isConnectAllowed(scriptId.toLong(), url)) {
+                    Log.w(TAG, "gmXhr blocked (not in @connect): $url")
+                    deliverXhrError(reqId, "url not in @connect allow-list: $url")
+                    return@launch
+                }
+
+                val method = details.optString("method", "GET").uppercase()
+                val headers = details.optJSONObject("headers")
+                val data = if (details.isNull("data")) null else details.optString("data")
+                val timeoutMs = details.optLong("timeout", 0L)
+
+                val builder = Request.Builder().url(url)
+                var contentType: String? = null
+                headers?.keys()?.forEach { name ->
+                    val v = headers.getString(name)
+                    if (name.equals("Content-Type", ignoreCase = true)) contentType = v
+                    builder.header(name, v)
+                }
+
+                if (method == "GET" || method == "HEAD") {
+                    builder.method(method, null)
+                } else {
+                    val body = (data ?: "").toRequestBody(contentType?.toMediaTypeOrNull())
+                    builder.method(method, body)
+                }
+
+                // Honor the script's per-request timeout (Tampermonkey semantics). When it
+                // fires, deliver a distinct "timeout" event so the script's ontimeout runs
+                // instead of leaving the request pending forever.
+                val client = if (timeoutMs > 0) {
+                    httpClient.newBuilder().callTimeout(timeoutMs, TimeUnit.MILLISECONDS).build()
+                } else {
+                    httpClient
+                }
+
+                client.newCall(builder.build()).execute().use { resp ->
+                    val bodyText = resp.body?.string().orEmpty()
+                    val headerText = resp.headers.joinToString("\r\n") { "${it.first}: ${it.second}" }
+                    val payload = JSONObject().apply {
+                        put("readyState", 4)
+                        put("status", resp.code)
+                        put("statusText", resp.message)
+                        put("responseText", bodyText)
+                        put("response", bodyText)
+                        put("responseHeaders", headerText)
+                        put("finalUrl", resp.request.url.toString())
+                    }
+                    deliverXhr(reqId, "load", payload.toString())
+                }
+            } catch (e: java.io.InterruptedIOException) {
+                Log.w(TAG, "gmXhr timeout: ${e.message}")
+                deliverXhr(reqId, "timeout", JSONObject().apply {
+                    put("readyState", 4); put("status", 0); put("statusText", "timeout")
+                }.toString())
+            } catch (e: Exception) {
+                Log.w(TAG, "gmXhr failed: ${e.message}")
+                deliverXhrError(reqId, e.message ?: "request failed")
+            }
+        }
+    }
+
+    private fun isConnectAllowed(scriptId: Long, url: String): Boolean {
+        val connects = userScriptManager.getById(scriptId)?.metadata?.connects ?: return false
+        if (connects.any { it == "*" }) return true
+        val host = try {
+            URI(url).host?.lowercase() ?: return false
+        } catch (e: Exception) {
+            return false
+        }
+        // page's own host is always allowed
+        val pageHost = try {
+            Uri.parse(webView.currentPageUrl ?: "").host?.lowercase()
+        } catch (e: Exception) {
+            null
+        }
+        if (pageHost != null && host == pageHost) return true
+        return connects.any { entry ->
+            val e = entry.lowercase()
+            e == host || host == e.removePrefix("*.") || host.endsWith(".$e") ||
+                (e.startsWith("*.") && host.endsWith(e.substring(1)))
+        }
+    }
+
+    private fun deliverXhrError(reqId: String, message: String) {
+        val payload = JSONObject().apply {
+            put("readyState", 4)
+            put("status", 0)
+            put("statusText", "error")
+            put("error", message)
+        }
+        deliverXhr(reqId, "error", payload.toString())
+    }
+
+    private fun deliverXhr(reqId: String, event: String, payloadJson: String) {
+        val js = "window.__einkbroGM && window.__einkbroGM.handleXhr(" +
+            "${JSONObject.quote(reqId)}, ${JSONObject.quote(event)}, ${JSONObject.quote(payloadJson)});"
+        coroutineScope.launch(Dispatchers.Main) {
+            if (webView.isAttachedToWindow) webView.evaluateJavascript(js, null)
+        }
+    }
+
+    // endregion
+
+    // region menu / misc
+
+    @JavascriptInterface
+    fun gmRegisterMenuCommand(scriptId: String, caption: String, fnId: String) {
+        coroutineScope.launch(Dispatchers.Main) {
+            webView.registerUserScriptMenuCommand(caption, fnId)
+        }
+    }
+
+    @JavascriptInterface
+    fun gmUnregisterMenuCommand(fnId: String) {
+        coroutineScope.launch(Dispatchers.Main) {
+            webView.unregisterUserScriptMenuCommand(fnId)
+        }
+    }
+
+    @JavascriptInterface
+    fun gmOpenInTab(url: String, active: Boolean) {
+        coroutineScope.launch(Dispatchers.Main) {
+            webView.openInNewTab(url)
+        }
+    }
+
+    @JavascriptInterface
+    fun gmSetClipboard(text: String) {
+        coroutineScope.launch(Dispatchers.Main) {
+            val cm = webView.context.getSystemService(Context.CLIPBOARD_SERVICE) as? ClipboardManager
+            cm?.setPrimaryClip(ClipData.newPlainText("userscript", text))
+        }
+    }
+
+    @JavascriptInterface
+    fun gmNotification(text: String) {
+        coroutineScope.launch(Dispatchers.Main) {
+            Toast.makeText(webView.context, text, Toast.LENGTH_SHORT).show()
+        }
+    }
+
+    @JavascriptInterface
+    fun gmLog(message: String) {
+        Log.d(TAG, "userscript: $message")
+    }
+
+    // endregion
+
+    companion object {
+        private const val TAG = "UserScriptBridge"
+    }
+}

--- a/app/src/main/java/info/plateaukao/einkbro/database/BookmarkDao.kt
+++ b/app/src/main/java/info/plateaukao/einkbro/database/BookmarkDao.kt
@@ -41,8 +41,10 @@ import org.koin.core.component.inject
         WhitelistDomain::class,
         JavascriptDomain::class,
         CookieDomain::class,
+        UserScript::class,
+        UserScriptValue::class,
     ],
-    version = 9,
+    version = 10,
     exportSchema = true
 )
 abstract class AppDatabase : RoomDatabase() {
@@ -56,6 +58,8 @@ abstract class AppDatabase : RoomDatabase() {
     abstract fun savedPageDao(): SavedPageDao
     abstract fun historyDao(): HistoryDao
     abstract fun domainListDao(): DomainListDao
+    abstract fun userScriptDao(): UserScriptDao
+    abstract fun userScriptValueDao(): UserScriptValueDao
 }
 
 @Dao
@@ -248,6 +252,13 @@ class BookmarkManager(private val context: Context) : KoinComponent {
         }
     }
 
+    private val migration9To10: Migration = object : Migration(9, 10) {
+        override fun migrate(database: SupportSQLiteDatabase) {
+            database.execSQL("CREATE TABLE IF NOT EXISTS `user_scripts` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `enabled` INTEGER NOT NULL, `code` TEXT NOT NULL, `sourceUrl` TEXT, `order` INTEGER NOT NULL)")
+            database.execSQL("CREATE TABLE IF NOT EXISTS `user_script_values` (`scriptId` INTEGER NOT NULL, `key` TEXT NOT NULL, `value` TEXT NOT NULL, PRIMARY KEY(`scriptId`, `key`))")
+        }
+    }
+
     val database = Room.databaseBuilder(context, AppDatabase::class.java, "einkbro_db")
         .addMigrations(migration1To2)
         .addMigrations(migration2To3)
@@ -257,9 +268,12 @@ class BookmarkManager(private val context: Context) : KoinComponent {
         .addMigrations(migration6To7)
         .addMigrations(migration7To8)
         .addMigrations(migration8To9)
+        .addMigrations(migration9To10)
         .build()
 
     val bookmarkDao = database.bookmarkDao()
+    val userScriptDao = database.userScriptDao()
+    val userScriptValueDao = database.userScriptValueDao()
 
     private val faviconDao = database.faviconDao()
     private val faviconInfos: MutableList<FaviconInfo> = mutableListOf()

--- a/app/src/main/java/info/plateaukao/einkbro/database/UserScript.kt
+++ b/app/src/main/java/info/plateaukao/einkbro/database/UserScript.kt
@@ -1,0 +1,30 @@
+package info.plateaukao.einkbro.database
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+/**
+ * A Tampermonkey-style userscript. The full script text (including the
+ * `// ==UserScript== ... // ==/UserScript==` metadata block) is stored verbatim
+ * in [code]; metadata is parsed on demand by UserScriptManager.
+ */
+@Entity(tableName = "user_scripts")
+data class UserScript(
+    @PrimaryKey(autoGenerate = true)
+    var id: Long = 0,
+    var name: String,
+    var enabled: Boolean = true,
+    var code: String,
+    var sourceUrl: String? = null,
+    var order: Int = 0,
+)
+
+/**
+ * Persistent key/value storage backing GM_setValue / GM_getValue, scoped per script.
+ */
+@Entity(tableName = "user_script_values", primaryKeys = ["scriptId", "key"])
+data class UserScriptValue(
+    var scriptId: Long,
+    var key: String,
+    var value: String,
+)

--- a/app/src/main/java/info/plateaukao/einkbro/database/UserScriptDao.kt
+++ b/app/src/main/java/info/plateaukao/einkbro/database/UserScriptDao.kt
@@ -1,0 +1,53 @@
+package info.plateaukao.einkbro.database
+
+import androidx.room.Dao
+import androidx.room.Delete
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import androidx.room.Update
+
+@Dao
+interface UserScriptDao {
+    @Query("SELECT * FROM user_scripts ORDER BY `order` ASC, id ASC")
+    suspend fun getAll(): List<UserScript>
+
+    @Query("SELECT * FROM user_scripts WHERE id = :id")
+    suspend fun getById(id: Long): UserScript?
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insert(userScript: UserScript): Long
+
+    @Update
+    suspend fun update(userScript: UserScript)
+
+    @Delete
+    suspend fun delete(userScript: UserScript)
+
+    @Query("DELETE FROM user_scripts WHERE id = :id")
+    suspend fun deleteById(id: Long)
+
+    @Query("DELETE FROM user_scripts")
+    suspend fun deleteAll()
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertAll(userScripts: List<UserScript>)
+}
+
+@Dao
+interface UserScriptValueDao {
+    @Query("SELECT value FROM user_script_values WHERE scriptId = :scriptId AND key = :key")
+    fun getValue(scriptId: Long, key: String): String?
+
+    @Query("SELECT key FROM user_script_values WHERE scriptId = :scriptId")
+    fun listKeys(scriptId: Long): List<String>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    fun setValue(value: UserScriptValue)
+
+    @Query("DELETE FROM user_script_values WHERE scriptId = :scriptId AND key = :key")
+    fun deleteValue(scriptId: Long, key: String)
+
+    @Query("DELETE FROM user_script_values WHERE scriptId = :scriptId")
+    fun deleteAllForScript(scriptId: Long)
+}

--- a/app/src/main/java/info/plateaukao/einkbro/userscript/UrlMatcher.kt
+++ b/app/src/main/java/info/plateaukao/einkbro/userscript/UrlMatcher.kt
@@ -1,0 +1,85 @@
+package info.plateaukao.einkbro.userscript
+
+/**
+ * Converts Tampermonkey `@match` / `@include` patterns to regexes and tests URLs.
+ *
+ * - `@match` follows the Chrome match-pattern grammar (scheme://host/path with `*`).
+ * - `@include` is looser: a glob where `*` matches any run of chars; a value that
+ *   looks like `/regex/` is treated as a regex.
+ */
+object UrlMatcher {
+
+    fun matches(url: String, matchPatterns: List<String>, includePatterns: List<String>): Boolean {
+        if (matchPatterns.isEmpty() && includePatterns.isEmpty()) return false
+        return matchPatterns.any { matchPattern(url, it) } ||
+            includePatterns.any { includePattern(url, it) }
+    }
+
+    fun isExcluded(url: String, excludePatterns: List<String>): Boolean =
+        excludePatterns.any { includePattern(url, it) || matchPattern(url, it) }
+
+    private val matchCache = HashMap<String, Regex?>()
+    private val includeCache = HashMap<String, Regex>()
+
+    private fun matchPattern(url: String, pattern: String): Boolean {
+        if (pattern == "*" || pattern == "<all_urls>") return url.startsWith("http")
+        val regex = matchCache.getOrPut(pattern) { compileMatch(pattern) } ?: return false
+        return regex.matches(url)
+    }
+
+    private fun includePattern(url: String, pattern: String): Boolean {
+        // /regex/ form
+        if (pattern.length > 2 && pattern.startsWith("/") && pattern.endsWith("/")) {
+            return try {
+                Regex(pattern.substring(1, pattern.length - 1)).containsMatchIn(url)
+            } catch (e: Exception) {
+                false
+            }
+        }
+        val regex = includeCache.getOrPut(pattern) { globToRegex(pattern) }
+        return regex.matches(url)
+    }
+
+    /** Chrome match pattern: <scheme>://<host><path> */
+    private fun compileMatch(pattern: String): Regex? {
+        val schemeSep = pattern.indexOf("://")
+        if (schemeSep < 0) return null
+        val scheme = pattern.substring(0, schemeSep)
+        val rest = pattern.substring(schemeSep + 3)
+        val slash = rest.indexOf('/')
+        if (slash < 0) return null
+        val host = rest.substring(0, slash)
+        val path = rest.substring(slash)
+
+        val schemeRegex = when (scheme) {
+            "*" -> "https?"
+            else -> Regex.escape(scheme)
+        }
+        val hostRegex = when {
+            host == "*" -> "[^/]+"
+            host.startsWith("*.") -> "(?:[^/]+\\.)?" + Regex.escape(host.substring(2))
+            else -> Regex.escape(host)
+        }
+        val pathRegex = globBody(path)
+        // Chrome match patterns match host only; tolerate an explicit :port in the URL.
+        return try {
+            Regex("^$schemeRegex://$hostRegex(?::\\d+)?$pathRegex$")
+        } catch (e: Exception) {
+            null
+        }
+    }
+
+    private fun globToRegex(pattern: String): Regex {
+        // Anchor loosely: include patterns without scheme should still match.
+        val body = globBody(pattern)
+        return try {
+            Regex("^$body$")
+        } catch (e: Exception) {
+            Regex(Regex.escape(pattern))
+        }
+    }
+
+    /** Escape everything except `*` (any chars). */
+    private fun globBody(glob: String): String =
+        glob.split("*").joinToString(".*") { Regex.escape(it) }
+}

--- a/app/src/main/java/info/plateaukao/einkbro/userscript/UserScriptManager.kt
+++ b/app/src/main/java/info/plateaukao/einkbro/userscript/UserScriptManager.kt
@@ -1,5 +1,7 @@
 package info.plateaukao.einkbro.userscript
 
+import android.content.Context
+import android.database.sqlite.SQLiteBlobTooBigException
 import android.util.Log
 import info.plateaukao.einkbro.database.BookmarkManager
 import info.plateaukao.einkbro.database.UserScript
@@ -15,6 +17,7 @@ import okhttp3.OkHttpClient
 import okhttp3.Request
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
+import java.io.File
 
 /** A userscript paired with its parsed metadata and resolved @require contents. */
 data class ParsedUserScript(
@@ -23,13 +26,25 @@ data class ParsedUserScript(
     var requiresContent: String = "",
 )
 
-class UserScriptManager : KoinComponent {
+class UserScriptManager(private val context: Context) : KoinComponent {
     private val bookmarkManager: BookmarkManager by inject()
     private val coroutineScope: CoroutineScope by inject()
     private val httpClient = OkHttpClient()
 
     private val userScriptDao get() = bookmarkManager.userScriptDao
     private val valueDao get() = bookmarkManager.userScriptValueDao
+
+    /**
+     * Script bodies are stored as files rather than inline in the DB row: a single
+     * userscript (e.g. Immersive Translate) can exceed several MB, which overflows
+     * Android's 2MB CursorWindow and makes the row unreadable (SQLiteBlobTooBigException).
+     * The DB row keeps only metadata; [UserScript.code] is persisted here, keyed by id.
+     */
+    private val scriptDir: File by lazy { File(context.filesDir, "userscripts").apply { mkdirs() } }
+    private fun codeFile(id: Long) = File(scriptDir, "$id.user.js")
+    private fun readCodeFile(id: Long): String? = codeFile(id).takeIf { it.exists() }?.readText()
+    private fun writeCodeFile(id: Long, code: String) = codeFile(id).writeText(code)
+    private fun deleteCodeFile(id: Long) { codeFile(id).delete() }
 
     @Volatile
     var scripts: List<ParsedUserScript> = emptyList()
@@ -40,11 +55,22 @@ class UserScriptManager : KoinComponent {
     }
 
     suspend fun reload() {
-        val loaded = userScriptDao.getAll().mapNotNull { script ->
+        val rows = try {
+            userScriptDao.getAll()
+        } catch (e: SQLiteBlobTooBigException) {
+            // Legacy rows stored the (multi-MB) script body inline and overflow the 2MB
+            // CursorWindow, so they can't be read back. Drop them — bodies now live in files.
+            Log.w(TAG, "Dropping oversized inline userscript rows: ${e.message}")
+            userScriptDao.deleteAll()
+            emptyList()
+        }
+        val loaded = rows.mapNotNull { row ->
+            // Body lives in a file; fall back to row.code for any pre-existing inline (small) rows.
+            val code = readCodeFile(row.id) ?: row.code
             try {
-                ParsedUserScript(script, UserScriptMetadata.parse(script.code))
+                ParsedUserScript(row.copy(code = code), UserScriptMetadata.parse(code))
             } catch (e: Exception) {
-                Log.w(TAG, "Failed to parse userscript ${script.name}: ${e.message}")
+                Log.w(TAG, "Failed to parse userscript ${row.name}: ${e.message}")
                 null
             }
         }
@@ -132,9 +158,11 @@ class UserScriptManager : KoinComponent {
     suspend fun add(code: String, sourceUrl: String? = null): Long {
         val metadata = UserScriptMetadata.parse(code)
         val maxOrder = scripts.maxOfOrNull { it.script.order } ?: 0
+        // Persist only metadata in the DB row; the body goes to a file keyed by the new id.
         val id = userScriptDao.insert(
-            UserScript(name = metadata.name, code = code, sourceUrl = sourceUrl, order = maxOrder + 1)
+            UserScript(name = metadata.name, code = "", sourceUrl = sourceUrl, order = maxOrder + 1)
         )
+        writeCodeFile(id, code)
         reload()
         return id
     }
@@ -146,7 +174,8 @@ class UserScriptManager : KoinComponent {
         } catch (e: Exception) {
             script.name
         }
-        userScriptDao.update(script.copy(name = name))
+        userScriptDao.update(script.copy(name = name, code = ""))
+        writeCodeFile(script.id, script.code)
         reload()
     }
 
@@ -159,6 +188,7 @@ class UserScriptManager : KoinComponent {
     suspend fun delete(id: Long) {
         withContext(Dispatchers.IO) { valueDao.deleteAllForScript(id) }
         userScriptDao.deleteById(id)
+        deleteCodeFile(id)
         reload()
     }
 

--- a/app/src/main/java/info/plateaukao/einkbro/userscript/UserScriptManager.kt
+++ b/app/src/main/java/info/plateaukao/einkbro/userscript/UserScriptManager.kt
@@ -1,0 +1,184 @@
+package info.plateaukao.einkbro.userscript
+
+import android.util.Log
+import info.plateaukao.einkbro.database.BookmarkManager
+import info.plateaukao.einkbro.database.UserScript
+import info.plateaukao.einkbro.database.UserScriptValue
+import info.plateaukao.einkbro.unit.HelperUnit
+import org.json.JSONArray
+import org.json.JSONObject
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
+
+/** A userscript paired with its parsed metadata and resolved @require contents. */
+data class ParsedUserScript(
+    val script: UserScript,
+    val metadata: UserScriptMetadata,
+    var requiresContent: String = "",
+)
+
+class UserScriptManager : KoinComponent {
+    private val bookmarkManager: BookmarkManager by inject()
+    private val coroutineScope: CoroutineScope by inject()
+    private val httpClient = OkHttpClient()
+
+    private val userScriptDao get() = bookmarkManager.userScriptDao
+    private val valueDao get() = bookmarkManager.userScriptValueDao
+
+    @Volatile
+    var scripts: List<ParsedUserScript> = emptyList()
+        private set
+
+    init {
+        coroutineScope.launch(Dispatchers.IO) { reload() }
+    }
+
+    suspend fun reload() {
+        val loaded = userScriptDao.getAll().mapNotNull { script ->
+            try {
+                ParsedUserScript(script, UserScriptMetadata.parse(script.code))
+            } catch (e: Exception) {
+                Log.w(TAG, "Failed to parse userscript ${script.name}: ${e.message}")
+                null
+            }
+        }
+        loaded.forEach { resolveRequires(it) }
+        scripts = loaded
+    }
+
+    private fun resolveRequires(parsed: ParsedUserScript) {
+        if (parsed.metadata.requires.isEmpty()) return
+        val sb = StringBuilder()
+        parsed.metadata.requires.forEach { url ->
+            val cached = requireCache[url]
+            if (cached != null) {
+                sb.append(cached).append('\n')
+                return@forEach
+            }
+            try {
+                val resp = httpClient.newCall(Request.Builder().url(url).build()).execute()
+                val body = resp.body?.string().orEmpty()
+                resp.close()
+                requireCache[url] = body
+                sb.append(body).append('\n')
+            } catch (e: Exception) {
+                Log.w(TAG, "Failed to fetch @require $url: ${e.message}")
+            }
+        }
+        parsed.requiresContent = sb.toString()
+    }
+
+    fun getMatchingScripts(url: String, runAt: RunAt): List<ParsedUserScript> {
+        if (!url.startsWith("http")) return emptyList()
+        return scripts.filter { parsed ->
+            parsed.script.enabled &&
+                parsed.metadata.runAt == runAt &&
+                UrlMatcher.matches(url, parsed.metadata.matches, parsed.metadata.includes) &&
+                !UrlMatcher.isExcluded(url, parsed.metadata.excludes)
+        }
+    }
+
+    fun getById(id: Long): ParsedUserScript? = scripts.firstOrNull { it.script.id == id }
+
+    /**
+     * Builds the JS to inject for a script: the templated GM shim, then any
+     * resolved @require contents, then the script body.
+     */
+    fun buildInjectionJs(parsed: ParsedUserScript): String {
+        val shim = HelperUnit.loadAssetFile("gm_shim.js")
+            .replace("__SCRIPT_ID__", parsed.script.id.toString())
+            .replace("__GM_INFO__", buildGmInfo(parsed))
+        return buildString {
+            append(shim).append('\n')
+            if (parsed.requiresContent.isNotEmpty()) append(parsed.requiresContent).append('\n')
+            append(parsed.script.code)
+            // Give the injected script a source URL so Chromium treats its exceptions as
+            // same-origin (full message + stack) instead of opaque "Script error.".
+            append("\n//# sourceURL=einkbro-userscript-").append(parsed.script.id).append(".user.js\n")
+        }
+    }
+
+    private fun buildGmInfo(parsed: ParsedUserScript): String {
+        val m = parsed.metadata
+        val scriptObj = JSONObject().apply {
+            put("name", m.name)
+            put("namespace", m.namespace)
+            put("version", m.version)
+            put("description", m.description)
+            put("runAt", if (m.runAt == RunAt.DOCUMENT_START) "document-start" else "document-end")
+            put("matches", JSONArray(m.matches))
+            put("includes", JSONArray(m.includes))
+            put("excludes", JSONArray(m.excludes))
+            put("grant", JSONArray(m.grants))
+            put("connects", JSONArray(m.connects))
+        }
+        return JSONObject().apply {
+            put("script", scriptObj)
+            put("scriptHandler", "EinkBro")
+            put("version", parsed.script.id.toString())
+            put("scriptMetaStr", "")
+            put("uuid", parsed.script.id.toString())
+        }.toString()
+    }
+
+    // region CRUD
+
+    suspend fun add(code: String, sourceUrl: String? = null): Long {
+        val metadata = UserScriptMetadata.parse(code)
+        val maxOrder = scripts.maxOfOrNull { it.script.order } ?: 0
+        val id = userScriptDao.insert(
+            UserScript(name = metadata.name, code = code, sourceUrl = sourceUrl, order = maxOrder + 1)
+        )
+        reload()
+        return id
+    }
+
+    suspend fun update(script: UserScript) {
+        // refresh name from metadata in case code changed
+        val name = try {
+            UserScriptMetadata.parse(script.code).name
+        } catch (e: Exception) {
+            script.name
+        }
+        userScriptDao.update(script.copy(name = name))
+        reload()
+    }
+
+    suspend fun setEnabled(id: Long, enabled: Boolean) {
+        val script = userScriptDao.getById(id) ?: return
+        userScriptDao.update(script.copy(enabled = enabled))
+        reload()
+    }
+
+    suspend fun delete(id: Long) {
+        withContext(Dispatchers.IO) { valueDao.deleteAllForScript(id) }
+        userScriptDao.deleteById(id)
+        reload()
+    }
+
+    // endregion
+
+    // region GM value storage — called from the WebView JS-bridge thread (not main)
+
+    fun gmGetValue(scriptId: Long, key: String): String? = valueDao.getValue(scriptId, key)
+
+    fun gmSetValue(scriptId: Long, key: String, value: String) =
+        valueDao.setValue(UserScriptValue(scriptId, key, value))
+
+    fun gmDeleteValue(scriptId: Long, key: String) = valueDao.deleteValue(scriptId, key)
+
+    fun gmListValues(scriptId: Long): List<String> = valueDao.listKeys(scriptId)
+
+    // endregion
+
+    companion object {
+        private const val TAG = "UserScriptManager"
+        private val requireCache = HashMap<String, String>()
+    }
+}

--- a/app/src/main/java/info/plateaukao/einkbro/userscript/UserScriptMetadata.kt
+++ b/app/src/main/java/info/plateaukao/einkbro/userscript/UserScriptMetadata.kt
@@ -1,0 +1,66 @@
+package info.plateaukao.einkbro.userscript
+
+/**
+ * Parsed `// ==UserScript== ... // ==/UserScript==` metadata block.
+ */
+data class UserScriptMetadata(
+    val name: String,
+    val namespace: String,
+    val version: String,
+    val description: String,
+    val matches: List<String>,
+    val includes: List<String>,
+    val excludes: List<String>,
+    val grants: List<String>,
+    val requires: List<String>,
+    val connects: List<String>,
+    val runAt: RunAt,
+    val noFrames: Boolean,
+) {
+    companion object {
+        private val BLOCK_REGEX =
+            Regex("""//\s*==UserScript==\s*\n(.*?)//\s*==/UserScript==""", RegexOption.DOT_MATCHES_ALL)
+        private val LINE_REGEX = Regex("""//\s*@([\w-]+)\s+(.*)""")
+
+        fun parse(code: String): UserScriptMetadata {
+            val block = BLOCK_REGEX.find(code)?.groupValues?.get(1).orEmpty()
+            val tags = mutableMapOf<String, MutableList<String>>()
+            block.lineSequence().forEach { line ->
+                val m = LINE_REGEX.find(line) ?: return@forEach
+                val key = m.groupValues[1].lowercase()
+                val value = m.groupValues[2].trim()
+                if (value.isNotEmpty()) tags.getOrPut(key) { mutableListOf() }.add(value)
+            }
+
+            fun first(vararg keys: String): String =
+                keys.firstNotNullOfOrNull { tags[it]?.firstOrNull() }.orEmpty()
+
+            fun all(vararg keys: String): List<String> =
+                keys.flatMap { tags[it].orEmpty() }
+
+            val runAt = when (first("run-at").lowercase()) {
+                "document-start" -> RunAt.DOCUMENT_START
+                "document-body" -> RunAt.DOCUMENT_START
+                "document-idle" -> RunAt.DOCUMENT_END
+                else -> RunAt.DOCUMENT_END // document-end is the Tampermonkey default
+            }
+
+            return UserScriptMetadata(
+                name = first("name").ifEmpty { "Unnamed script" },
+                namespace = first("namespace"),
+                version = first("version"),
+                description = first("description"),
+                matches = all("match"),
+                includes = all("include"),
+                excludes = all("exclude", "exclude-match"),
+                grants = all("grant"),
+                requires = all("require"),
+                connects = all("connect"),
+                runAt = runAt,
+                noFrames = tags.containsKey("noframes"),
+            )
+        }
+    }
+}
+
+enum class RunAt { DOCUMENT_START, DOCUMENT_END }

--- a/app/src/main/java/info/plateaukao/einkbro/view/EBWebView.kt
+++ b/app/src/main/java/info/plateaukao/einkbro/view/EBWebView.kt
@@ -329,7 +329,42 @@ open class EBWebView(
 
     private fun setupJsWebInterface() {
         addJavascriptInterface(JsWebInterface(this, webViewCallback as? JsBrowserCallback), "androidApp")
+        addJavascriptInterface(
+            info.plateaukao.einkbro.browser.UserScriptBridge(this),
+            "einkbroGM",
+        )
     }
+
+    // region userscript support
+
+    /**
+     * The current page URL, captured on the main thread by the WebViewClient so the
+     * userscript bridge can read it from its background thread without touching
+     * WebView.getUrl() (which must only be called on the UI thread).
+     */
+    @Volatile
+    var currentPageUrl: String? = null
+
+    /** Menu commands registered via GM_registerMenuCommand on the current page (caption to fnId). */
+    val userScriptMenuCommands = LinkedHashMap<String, String>()
+
+    fun registerUserScriptMenuCommand(caption: String, fnId: String) {
+        userScriptMenuCommands[caption] = fnId
+    }
+
+    fun unregisterUserScriptMenuCommand(fnId: String) {
+        userScriptMenuCommands.values.remove(fnId)
+    }
+
+    fun invokeUserScriptMenuCommand(fnId: String) {
+        evaluateJavascript("window.__einkbroGM && window.__einkbroGM.invokeMenu('$fnId');", null)
+    }
+
+    fun openInNewTab(url: String) {
+        (webViewCallback as? info.plateaukao.einkbro.browser.TabController)?.addNewTab(url)
+    }
+
+    // endregion
 
     private fun updateDarkMode() {
         if (config.display.darkMode == DarkMode.DISABLED) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -307,6 +307,14 @@
     <string name="setting_title_import_bookmarks">Import bookmarks</string>
     <string name="setting_title_incognito">Incognito mode</string>
     <string name="back">Back</string>
+    <string name="setting_title_userscripts">Userscripts</string>
+    <string name="setting_summary_userscripts">Manage Tampermonkey-style userscripts</string>
+    <string name="userscript_add">Add userscript</string>
+    <string name="userscript_empty">No userscripts installed yet. Tap + to add one, or open a .user.js link.</string>
+    <string name="userscript_install_from_url">Install from URL</string>
+    <string name="userscript_fetch">Fetch</string>
+    <string name="userscript_code">Userscript code</string>
+    <string name="userscript_install_prompt">Install this userscript?</string>
     <string name="refresh">Refresh</string>
     <string name="touch_turn_page">Touch turn page</string>
     <string name="tab_preview">Tab preview</string>


### PR DESCRIPTION
## Summary

Adds a Tampermonkey-style userscript engine to EinkBro: user-installed userscripts are injected into matching pages with a `GM_*`/`GM.*` API surface (cross-origin `GM_xmlhttpRequest` gated by `@connect`, persistent value storage, menu commands, `GM_addStyle`/`addElement`, `GM_openInTab`). Verified with Immersive Translate rendering bilingual text and a hand-written paragraph translator.

### Engine
- Room v9→v10: `user_scripts` + `user_script_values` tables (`migration9To10`)
- `userscript/` package: metadata parser, `@match`/`@include` URL matcher, `UserScriptManager` (Koin single) for cache/matching/injection-blob building
- `assets/gm_shim.js`: `GM_*`/`GM.*` shim; `UserScriptBridge` `@JavascriptInterface` (`einkbroGM`) backing it with OkHttp + `@connect` allow-listing
- Inject document-start in `onPageStarted`, document-end in `onPageFinished`; intercept `.user.js` URLs in `shouldOverrideUrlLoading`
- `UserScriptListActivity` (Settings → Start control → Userscripts): list/add (paste|URL)/edit/delete/toggle

### Large-script storage fix
Installing a large userscript (~4MB Immersive Translate) crashed on OK: the body was stored inline in the `code` column, and `SELECT * FROM user_scripts` overflowed Android's 2MB `CursorWindow` (`SQLiteBlobTooBigException`). The INSERT had already committed, so the app then crashed on every launch.

- Script bodies now stored as files (`files/userscripts/<id>.user.js`); the DB row keeps only metadata with an empty `code` column
- `reload()` reads bodies back from files (falls back to inline `code` for small legacy rows) and catches `SQLiteBlobTooBigException` to auto-recover an already-poisoned DB by dropping unreadable rows

## Testing
Verified on a Hisense A7: fetched and installed the 4MB Immersive Translate userscript without crashing; body written to disk (4,037,187 bytes), DB row tiny; already-poisoned DB auto-recovered on launch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)