### PR TITLE
feat(ai): real HTML source, JS eval, web search, and EPUB export for the LLM agent

### DIFF
--- a/app/src/main/java/info/plateaukao/einkbro/activity/delegates/TaskMenuDelegate.kt
+++ b/app/src/main/java/info/plateaukao/einkbro/activity/delegates/TaskMenuDelegate.kt
@@ -94,6 +94,7 @@ class TaskMenuDelegate(
                 text = rawText,
                 links = links,
                 rawHtml = rawHtml,
+                originWebView = java.lang.ref.WeakReference(current),
             )
             chatWithWebAgent(prompt, snapshot)
         }

--- a/app/src/main/java/info/plateaukao/einkbro/browser/ChatWebInterface.kt
+++ b/app/src/main/java/info/plateaukao/einkbro/browser/ChatWebInterface.kt
@@ -19,6 +19,7 @@ import info.plateaukao.einkbro.task.BrowserTools
 import info.plateaukao.einkbro.task.BrowserToolsImpl
 import info.plateaukao.einkbro.task.InitialPageSnapshot
 import info.plateaukao.einkbro.task.TaskProgress
+import info.plateaukao.einkbro.task.ToolTextWindow
 import info.plateaukao.einkbro.viewmodel.TtsViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -30,6 +31,7 @@ import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonArray
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.intOrNull
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import org.koin.core.component.KoinComponent
@@ -289,7 +291,7 @@ class ChatWebInterface(
                     agentToolsInitialized = true
                     val text = agentTools.initialPageText().trim()
                     if (text.isBlank()) "error: no initial page text captured"
-                    else text.take(MAX_TOOL_RESULT_CHARS)
+                    else windowToolResult(text, args)
                 }
                 "open_url" -> {
                     val url = args["url"]?.jsonPrimitive?.contentOrNull
@@ -298,11 +300,62 @@ class ChatWebInterface(
                     val ok = agentTools.openUrlInBg(url)
                     if (ok) "ok: loaded $url" else "error: failed to load $url"
                 }
+                "web_search" -> {
+                    val query = args["query"]?.jsonPrimitive?.contentOrNull
+                        ?.takeIf { it.isNotBlank() }
+                        ?: return "error: missing query"
+                    agentToolsInitialized = true
+                    val ok = agentTools.searchInBg(query)
+                    if (!ok) "error: search results page failed to load"
+                    else encodeLinks(agentTools.currentBgPageLinks())
+                }
+                "run_javascript" -> {
+                    val code = args["code"]?.jsonPrimitive?.contentOrNull
+                        ?.takeIf { it.isNotBlank() }
+                        ?: return "error: missing code"
+                    val target = args["target"]?.jsonPrimitive?.contentOrNull ?: "tab"
+                    agentToolsInitialized = true
+                    val result = when (target) {
+                        "background" -> agentTools.runJavascriptInBg(code)
+                            ?: "error: no page loaded — call open_url first"
+                        else -> agentTools.runJavascriptInInitialTab(code)
+                            ?: "error: the originating tab is no longer available"
+                    }
+                    if (result.length > MAX_TOOL_RESULT_CHARS) windowToolResult(result, args)
+                    else result
+                }
+                "save_epub" -> {
+                    val bookTitle = args["book_title"]?.jsonPrimitive?.contentOrNull
+                        ?.takeIf { it.isNotBlank() }
+                        ?: return "error: missing book_title"
+                    val chapterSpecs = (args["chapters"] as? JsonArray).orEmpty().mapNotNull { el ->
+                        val obj = el as? JsonObject ?: return@mapNotNull null
+                        val url = obj["url"]?.jsonPrimitive?.contentOrNull ?: return@mapNotNull null
+                        BrowserTools.EpubChapterSpec(
+                            url = url,
+                            title = obj["title"]?.jsonPrimitive?.contentOrNull.orEmpty(),
+                        )
+                    }
+                    if (chapterSpecs.isEmpty()) return "error: chapters array has no valid entries"
+                    agentToolsInitialized = true
+                    var loadedCount = 0
+                    val location = agentTools.saveEpub(bookTitle, chapterSpecs) { index, total, title ->
+                        loadedCount++
+                        appendBubble("\n\n_📖 chapter $index/$total: ${escapeMd(title)}_")
+                    }
+                    when {
+                        location == null -> "error: failed to save epub (no chapters loaded or write failed)"
+                        loadedCount < chapterSpecs.size ->
+                            "ok: saved $loadedCount of ${chapterSpecs.size} chapters to $location " +
+                                "(the other pages failed to load)"
+                        else -> "ok: saved $loadedCount chapters to $location"
+                    }
+                }
                 "read_current_page" -> {
                     agentToolsInitialized = true
                     val text = agentTools.currentBgPageText().trim()
                     if (text.isBlank()) "error: no page loaded or page body is empty"
-                    else text.take(MAX_TOOL_RESULT_CHARS)
+                    else windowToolResult(text, args)
                 }
                 "get_page_links" -> {
                     agentToolsInitialized = true
@@ -329,7 +382,23 @@ class ChatWebInterface(
                     agentToolsInitialized = true
                     val html = agentTools.initialPageRawHtml()
                     if (html.isBlank()) "error: no initial page HTML captured"
-                    else html.take(MAX_TOOL_RESULT_CHARS)
+                    else windowToolResult(html, args)
+                }
+                "read_page_source" -> {
+                    agentToolsInitialized = true
+                    val url = args["url"]?.jsonPrimitive?.contentOrNull
+                        ?.takeIf { it.isNotBlank() }
+                        ?: agentTools.initialPageUrl()
+                    if (url.isBlank()) {
+                        "error: no url available — pass a url argument"
+                    } else {
+                        val html = agentTools.fetchPageSource(url)
+                        when {
+                            html == null -> "error: failed to download $url"
+                            html.isBlank() -> "error: empty document at $url"
+                            else -> windowToolResult(html, args)
+                        }
+                    }
                 }
                 "get_domain_javascript" -> {
                     agentToolsInitialized = true
@@ -371,6 +440,15 @@ class ChatWebInterface(
             "error: ${e.message}"
         }
     }
+
+    /** Windows a large tool result, honoring the optional `offset`/`search` tool args. */
+    private fun windowToolResult(content: String, args: JsonObject): String =
+        ToolTextWindow.window(
+            content = content,
+            maxChars = MAX_TOOL_RESULT_CHARS,
+            offset = args["offset"]?.jsonPrimitive?.intOrNull ?: 0,
+            search = args["search"]?.jsonPrimitive?.contentOrNull,
+        )
 
     private fun encodeLinks(links: List<BrowserTools.Link>): String {
         if (links.isEmpty()) return "[]"

--- a/app/src/main/java/info/plateaukao/einkbro/epub/EpubManager.kt
+++ b/app/src/main/java/info/plateaukao/einkbro/epub/EpubManager.kt
@@ -91,6 +91,40 @@ class EpubManager(private val context: Context) : KoinComponent {
         }
     }
 
+    /**
+     * Non-interactive EPUB export used by agent tasks: builds a NEW book from
+     * [chapters] and writes it to [fileUri]. No dialogs, no reader launch, no
+     * saved-file bookkeeping — callers handle that. Returns true on success.
+     */
+    suspend fun saveEpubDirectly(
+        fileUri: Uri,
+        bookName: String,
+        chapters: List<EpubChapterContent>,
+    ): Boolean = withContext(Dispatchers.IO) {
+        try {
+            val domain = Uri.parse(chapters.firstOrNull()?.url.orEmpty()).host ?: "EinkBro"
+            val book = createBook(domain, bookName)
+            chapters.forEachIndexed { index, chapter ->
+                val chapterIndex = index + 1
+                val webUri = Uri.parse(chapter.url)
+                val (processedHtml, imageMap) = processHtmlString(
+                    chapter.html,
+                    chapterIndex,
+                    "${webUri.scheme}://${webUri.host}/"
+                )
+                book.addSection(
+                    chapter.title,
+                    Resource(processedHtml.byteInputStream(), "chapter$chapterIndex.html")
+                )
+                saveImageResources(book, imageMap) {}
+            }
+            saveBook(book, fileUri)
+        } catch (e: Exception) {
+            Log.e(TAG, "saveEpubDirectly failed", e)
+            false
+        }
+    }
+
     private suspend fun getChapterName(defaultTitle: String?): String? {
         val chapterName = defaultTitle ?: "no title"
         return TextInputDialog(
@@ -235,13 +269,14 @@ class EpubManager(private val context: Context) : KoinComponent {
         }
     }
 
-    private fun saveBook(book: Book, uri: Uri) {
-        try {
-            val outputStream = context.contentResolver.openOutputStream(uri)
-            EpubWriter().write(book, outputStream)
-            outputStream?.close()
+    private fun saveBook(book: Book, uri: Uri): Boolean {
+        return try {
+            val outputStream = context.contentResolver.openOutputStream(uri) ?: return false
+            outputStream.use { EpubWriter().write(book, it) }
+            true
         } catch (e: IOException) {
             e.printStackTrace()
+            false
         }
     }
 
@@ -349,3 +384,7 @@ class EpubManager(private val context: Context) : KoinComponent {
         const val EINKBRO_IDENTIFIER_VALUE = "EinkBro"
     }
 }
+
+/** One resolved chapter for [EpubManager.saveEpubDirectly]: already-extracted reader
+ *  [html] plus the source [url] (used for the base URI and image resolution). */
+data class EpubChapterContent(val title: String, val html: String, val url: String)

--- a/app/src/main/java/info/plateaukao/einkbro/task/AgentToolSchema.kt
+++ b/app/src/main/java/info/plateaukao/einkbro/task/AgentToolSchema.kt
@@ -26,8 +26,11 @@ object AgentToolSchema {
             name = "read_initial_page",
             description = "Return the reader-mode text of the page the user was viewing when " +
                 "they triggered this task. Use when the user wants the current page summarized/" +
-                "translated/analyzed. Zero-cost lookup.",
-            parameters = """{"type":"object","properties":{},"required":[]}""",
+                "translated/analyzed. Zero-cost lookup. Long documents are windowed — " +
+                "pass offset to continue reading.",
+            parameters = """
+                {"type":"object","properties":{"offset":{"type":"integer","description":"Character offset to start from (default 0)"}},"required":[]}
+            """.trimIndent(),
         ),
         toolDef(
             name = "open_url",
@@ -39,10 +42,48 @@ object AgentToolSchema {
             """.trimIndent(),
         ),
         toolDef(
+            name = "web_search",
+            description = "Search the web using the user's configured search engine. Loads the " +
+                "results page in the off-screen WebView and returns its links (text + href). " +
+                "Follow up with read_current_page for result snippets, or open_url to visit a " +
+                "result. Use whenever you need a page you don't have a URL for.",
+            parameters = """
+                {"type":"object","properties":{"query":{"type":"string","description":"Search terms"}},"required":["query"]}
+            """.trimIndent(),
+        ),
+        toolDef(
+            name = "run_javascript",
+            description = "Evaluate JavaScript and return its completion value (JSON-encoded). " +
+                "target 'tab' (default) runs in the LIVE tab the user was viewing — DOM " +
+                "changes are immediately visible to the user, so use it to TEST a selector " +
+                "or element removal before persisting it with set_domain_javascript. " +
+                "target 'background' runs in the off-screen WebView (call open_url first) — " +
+                "use it to extract structured data (prices, dates, table rows) that " +
+                "reader-mode text loses. Make the last statement an expression that yields " +
+                "the value; use JSON.stringify for objects/arrays.",
+            parameters = """
+                {"type":"object","properties":{"code":{"type":"string","description":"JavaScript source to evaluate"},"target":{"type":"string","enum":["tab","background"],"description":"'tab' = live originating tab (default); 'background' = off-screen WebView"}},"required":["code"]}
+            """.trimIndent(),
+        ),
+        toolDef(
+            name = "save_epub",
+            description = "Fetch one or more pages and save their reader-mode content as " +
+                "chapters of a new EPUB file in the device's Downloads folder. Use when the " +
+                "user wants to keep articles for offline/e-reader reading (e.g. 'save these " +
+                "three articles as a book'). Each chapter loads in the off-screen WebView, " +
+                "so allow a few seconds per page. Returns the saved file location.",
+            parameters = """
+                {"type":"object","properties":{"book_title":{"type":"string","description":"EPUB book title, also used as the file name"},"chapters":{"type":"array","description":"Pages to save, in reading order","items":{"type":"object","properties":{"url":{"type":"string","description":"Absolute http(s) URL of the page"},"title":{"type":"string","description":"Chapter title; defaults to the page title"}},"required":["url"]}}},"required":["book_title","chapters"]}
+            """.trimIndent(),
+        ),
+        toolDef(
             name = "read_current_page",
             description = "Return the reader-mode text of the currently loaded off-screen page. " +
-                "Call open_url first.",
-            parameters = """{"type":"object","properties":{},"required":[]}""",
+                "Call open_url first. Long documents are windowed — pass offset to continue " +
+                "reading.",
+            parameters = """
+                {"type":"object","properties":{"offset":{"type":"integer","description":"Character offset to start from (default 0)"}},"required":[]}
+            """.trimIndent(),
         ),
         toolDef(
             name = "get_page_links",
@@ -74,12 +115,28 @@ object AgentToolSchema {
         ),
         toolDef(
             name = "read_initial_html",
-            description = "Return the raw `document.body.innerHTML` of the page the user was " +
-                "viewing when they triggered this task. Use this when the user describes a DOM " +
-                "element to act on (banner, popup, ad, modal) — read_initial_page returns " +
-                "reader-mode text which strips those out. Result is truncated; you may need " +
-                "to scan strategically. Zero-cost lookup.",
-            parameters = """{"type":"object","properties":{},"required":[]}""",
+            description = "Return the rendered `document.body.innerHTML` of the page the user " +
+                "was viewing — the live DOM AFTER JavaScript ran. Use it to inspect elements " +
+                "that are injected at runtime (popups, late-loading ads, cookie banners). For " +
+                "the original served markup use read_page_source instead. Long documents are " +
+                "windowed: page through with offset, or jump straight to an element with " +
+                "search (e.g. visible text the user quoted, or a class/id fragment).",
+            parameters = """
+                {"type":"object","properties":{"offset":{"type":"integer","description":"Character offset to start from (default 0)"},"search":{"type":"string","description":"Jump to the first occurrence of this string at/after offset (case-insensitive)"}},"required":[]}
+            """.trimIndent(),
+        ),
+        toolDef(
+            name = "read_page_source",
+            description = "Download and return the page's REAL HTML source — the exact markup " +
+                "the server sent, before any JavaScript ran (view-source equivalent, fetched " +
+                "with the browser's cookies and user agent). Defaults to the originating page; " +
+                "pass url for any other page. This is the ground truth for writing precise CSS " +
+                "selectors and DOM patches: ad containers, class/id names, hidden elements, " +
+                "inline scripts. Long documents are windowed: page through with offset, or " +
+                "jump straight to an element with search.",
+            parameters = """
+                {"type":"object","properties":{"url":{"type":"string","description":"Absolute http(s) URL; omit to read the originating page"},"offset":{"type":"integer","description":"Character offset to start from (default 0)"},"search":{"type":"string","description":"Jump to the first occurrence of this string at/after offset (case-insensitive)"}},"required":[]}
+            """.trimIndent(),
         ),
         toolDef(
             name = "get_domain_javascript",
@@ -139,24 +196,40 @@ object AgentToolSchema {
         "You help the user with multi-step browsing tasks by calling the provided tools. " +
         "The user triggered this task while viewing a specific page — call " +
         "get_initial_page_links or read_initial_page FIRST to inspect what they were " +
-        "looking at. Use open_url only when you need to navigate somewhere new. Never ask " +
+        "looking at. Use open_url only when you need to navigate somewhere new, and " +
+        "web_search when you need a page you don't have a URL for. Never ask " +
         "the user to paste content; fetch it via tools. When the user asks you to read, " +
         "speak, or narrate something out loud, call the speak tool (plain-text form, no " +
-        "markdown). Be decisive and frugal: fewer tool calls is better.\n\n" +
+        "markdown). When the user wants articles kept for offline or e-reader reading, " +
+        "call save_epub with the URLs as chapters. Be decisive and frugal: fewer tool " +
+        "calls is better.\n\n" +
         "DOM-PATCH WORKFLOW: When the user asks you to remove a banner, popup, modal, ad, " +
-        "cookie notice, or any other element from a site, follow this sequence: " +
-        "(1) call read_initial_html and locate the offending element by the text the user " +
-        "named or a stable structural cue; " +
+        "cookie notice, or any other element from a site (or show/hide specific elements), " +
+        "follow this sequence: " +
+        "(1) locate the offending element in the page's HTML. read_page_source gives the " +
+        "REAL served markup (best for stable selectors: ad containers, class/id names); " +
+        "read_initial_html gives the rendered DOM after JavaScript (best for elements " +
+        "injected at runtime). Use the search parameter with text the user quoted or a " +
+        "likely class/id fragment (e.g. 'ad', 'banner', 'cookie') instead of paging " +
+        "blindly through offsets; " +
         "(2) call get_domain_javascript to see what's already saved for this host; " +
         "(3) compose a self-contained JS snippet that finds and removes/hides the element. " +
         "Prefer querySelectorAll plus textContent matching over fragile DOM paths. Always " +
         "wrap in try/catch. For elements that appear after page load (popups, lazy " +
         "modals), use a MutationObserver or a short setInterval re-check. " +
-        "(4) call set_domain_javascript with the FULL combined script — your new code " +
-        "concatenated with whatever get_domain_javascript returned, so you don't clobber " +
-        "earlier rules. EinkBro will auto-run this after every page load on the host. " +
-        "Use set_domain_css instead if a CSS rule (e.g. `display:none`) suffices — it's " +
-        "lighter and harder to break. Tell the user in finish what selector/text you " +
-        "matched on so they can revert via Site Settings if it misfires.\n\n" +
+        "(4) TEST the snippet first: call run_javascript with target 'tab' to run it on " +
+        "the live page the user is viewing, returning a before/after element count so " +
+        "you can verify it actually matched and removed something (the user sees the " +
+        "element vanish immediately). Wrap the test snippet in try/catch and return the " +
+        "caught error message as a string — a thrown error otherwise looks identical to " +
+        "zero matches. If it matched nothing, refine the selector and re-test instead " +
+        "of persisting a broken rule. " +
+        "(5) once verified, call set_domain_javascript with the FULL combined script — " +
+        "your new code concatenated with whatever get_domain_javascript returned, so you " +
+        "don't clobber earlier rules. EinkBro will auto-run this after every page load " +
+        "on the host. Use set_domain_css instead if a CSS rule (e.g. `display:none`) " +
+        "suffices — it's lighter and harder to break. Tell the user in finish what " +
+        "selector/text you matched on so they can revert via Site Settings if it " +
+        "misfires.\n\n" +
         "Always end the task by calling the finish tool with your final answer as markdown."
 }

--- a/app/src/main/java/info/plateaukao/einkbro/task/BrowserTools.kt
+++ b/app/src/main/java/info/plateaukao/einkbro/task/BrowserTools.kt
@@ -24,6 +24,10 @@ data class InitialPageSnapshot(
      *  that need to identify DOM elements the user described — `text` is reader-mode
      *  cleaned and strips out exactly the banners/popups callers want to target. */
     val rawHtml: String = "",
+    /** Weak reference to the live originating tab, so the agent can run JavaScript on
+     *  it with user-visible effect (e.g. test a removal selector before persisting it).
+     *  Weak because the user may close that tab while the agent chat is still open. */
+    val originWebView: java.lang.ref.WeakReference<info.plateaukao.einkbro.view.EBWebView>? = null,
 )
 
 interface BrowserTools {
@@ -42,6 +46,17 @@ interface BrowserTools {
     /** Raw `document.body.innerHTML` of the originating page. Captured at task entry —
      *  zero-cost lookup. Empty string if the snapshot did not include HTML. */
     fun initialPageRawHtml(): String
+
+    // ── Page source (network-level) ─────────────────────────────────────
+
+    /**
+     * Downloads the real HTML source of [url] — the exact markup the server sent,
+     * before any JavaScript ran (view-source equivalent). Sends the browser's
+     * User-Agent and the cookies stored for [url] so auth-walled pages match what
+     * the WebView would receive. The last result is cached per-URL so paged tool
+     * reads don't re-download. Returns null on network/HTTP failure or non-http(s) URLs.
+     */
+    suspend fun fetchPageSource(url: String): String?
 
     // ── Domain config (per-host CSS/JS that auto-injects on page load) ─────
     //
@@ -63,10 +78,25 @@ interface BrowserTools {
     /** Replaces the customCss for the originating page's host. Pass "" to clear. */
     fun setInitialDomainCss(code: String)
 
+    // ── JavaScript evaluation ───────────────────────────────────────────
+
+    /** Evaluates [code] in the off-screen WebView and returns the JSON-encoded
+     *  completion value. Null when no page has been loaded yet. */
+    suspend fun runJavascriptInBg(code: String): String?
+
+    /** Evaluates [code] in the LIVE tab the user was viewing when the task started —
+     *  DOM changes are immediately visible to the user. Returns the JSON-encoded
+     *  completion value, or null when that tab has been closed/collected. */
+    suspend fun runJavascriptInInitialTab(code: String): String?
+
     // ── Navigation / content ────────────────────────────────────────────
 
     /** Loads [url] in the off-screen WebView and awaits page load. Returns false on timeout. */
     suspend fun openUrlInBg(url: String): Boolean
+
+    /** Loads the user's configured search engine with [query] in the off-screen WebView.
+     *  Follow with [currentBgPageLinks]/[currentBgPageText] to read the results. */
+    suspend fun searchInBg(query: String): Boolean
 
     /** Reader-mode text of the off-screen WebView's current page (empty if none loaded). */
     suspend fun currentBgPageText(): String
@@ -126,8 +156,27 @@ interface BrowserTools {
     /** Commit the final markdown result. The runner marks the task Done after this. */
     fun finish(markdown: String)
 
+    // ── EPUB export ─────────────────────────────────────────────────────
+
+    /**
+     * Fetches each chapter URL in the off-screen WebView, extracts its reader-mode
+     * HTML, and writes all chapters into a new EPUB in the device's public Downloads
+     * folder (registered in the app's saved-EPUB list). Chapters that fail to load
+     * are skipped; [onChapterLoaded] fires as (index, total, chapterTitle) for each
+     * successful one. Returns a human-readable saved location, or null when nothing
+     * could be saved.
+     */
+    suspend fun saveEpub(
+        bookName: String,
+        chapters: List<EpubChapterSpec>,
+        onChapterLoaded: (Int, Int, String) -> Unit = { _, _, _ -> },
+    ): String?
+
     /** Releases the off-screen WebView. Called by TaskRunner when done. */
     fun dispose()
 
     data class Link(val text: String, val href: String)
+
+    /** One requested EPUB chapter: [url] to fetch, optional [title] (defaults to page title). */
+    data class EpubChapterSpec(val url: String, val title: String = "")
 }

--- a/app/src/main/java/info/plateaukao/einkbro/task/BrowserToolsImpl.kt
+++ b/app/src/main/java/info/plateaukao/einkbro/task/BrowserToolsImpl.kt
@@ -1,23 +1,44 @@
 package info.plateaukao.einkbro.task
 
+import android.Manifest
+import android.content.ContentValues
 import android.content.Context
+import android.content.pm.PackageManager
+import android.net.Uri
+import android.os.Build
+import android.os.Environment
+import android.provider.MediaStore
+import android.webkit.CookieManager
+import android.webkit.WebSettings
+import androidx.core.content.ContextCompat
 import info.plateaukao.einkbro.activity.BrowserState
 import info.plateaukao.einkbro.browser.WebViewCallback
 import info.plateaukao.einkbro.data.remote.ChatMessage
 import info.plateaukao.einkbro.data.remote.ChatRole
 import info.plateaukao.einkbro.data.remote.OpenAiRepository
 import info.plateaukao.einkbro.database.DomainConfigurationData
+import info.plateaukao.einkbro.epub.EpubChapterContent
+import info.plateaukao.einkbro.epub.EpubManager
 import info.plateaukao.einkbro.preference.ChatGPTActionInfo
 import info.plateaukao.einkbro.preference.ConfigManager
 import info.plateaukao.einkbro.preference.GptActionType
+import info.plateaukao.einkbro.preference.SavedFileInfo
+import info.plateaukao.einkbro.unit.BrowserUnit
+import info.plateaukao.einkbro.util.Constants
 import info.plateaukao.einkbro.view.EBWebView
 import info.plateaukao.einkbro.viewmodel.TtsViewModel
+import kotlin.coroutines.resume
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import java.io.File
+import java.util.concurrent.TimeUnit
 
 /**
  * Default [BrowserTools] implementation backed by an off-screen [EBWebView] and the
@@ -41,6 +62,35 @@ class BrowserToolsImpl(
 
     private val json = Json { ignoreUnknownKeys = true }
 
+    // ── JavaScript evaluation ───────────────────────────────────────────
+
+    override suspend fun runJavascriptInBg(code: String): String? {
+        val wv = bgWebView ?: return null
+        return evaluateJs(wv, code)
+    }
+
+    override suspend fun runJavascriptInInitialTab(code: String): String? {
+        val wv = initialSnapshot?.originWebView?.get() ?: return null
+        return evaluateJs(wv, code)
+    }
+
+    /** Null when [webView] has already been destroyed (e.g. the user closed that tab). */
+    private suspend fun evaluateJs(webView: EBWebView, code: String): String? =
+        withContext(Dispatchers.Main) {
+            if (webView.isWebViewDestroyed) return@withContext null
+            withTimeoutOrNull(JS_EVAL_TIMEOUT_MS) {
+                suspendCancellableCoroutine { cont ->
+                    try {
+                        webView.evaluateJavascript(code) { result ->
+                            if (cont.isActive) cont.resume(result ?: "null")
+                        }
+                    } catch (e: Exception) {
+                        if (cont.isActive) cont.resume("error: ${e.message}")
+                    }
+                }
+            } ?: "error: javascript evaluation timed out"
+        }
+
     // ── Navigation / content ────────────────────────────────────────────
 
     override suspend fun openUrlInBg(url: String): Boolean {
@@ -53,9 +103,16 @@ class BrowserToolsImpl(
         return ok
     }
 
+    override suspend fun searchInBg(query: String): Boolean {
+        val searchUrl = BrowserUnit.queryWrapper(context, query)
+        return openUrlInBg(searchUrl)
+    }
+
     override suspend fun currentBgPageText(): String {
         val wv = bgWebView ?: return ""
-        return withContext(Dispatchers.Main) { wv.getRawText() }
+        return withContext(Dispatchers.Main) {
+            withTimeoutOrNull(READER_EXTRACT_TIMEOUT_MS) { wv.getRawText() }
+        } ?: ""
     }
 
     override suspend fun currentBgPageLinks(): List<BrowserTools.Link> {
@@ -86,6 +143,59 @@ class BrowserToolsImpl(
     override fun initialPageText(): String = initialSnapshot?.text.orEmpty()
     override fun initialPageLinks(): List<BrowserTools.Link> = initialSnapshot?.links.orEmpty()
     override fun initialPageRawHtml(): String = initialSnapshot?.rawHtml.orEmpty()
+
+    // ── Page source (network-level) ─────────────────────────────────────
+
+    private val sourceClient: OkHttpClient by lazy {
+        OkHttpClient.Builder()
+            .connectTimeout(15, TimeUnit.SECONDS)
+            .readTimeout(20, TimeUnit.SECONDS)
+            .build()
+    }
+
+    /** Last fetched (url, html) pair so paged tool reads don't re-download. */
+    private var pageSourceCache: Pair<String, String>? = null
+
+    override suspend fun fetchPageSource(url: String): String? {
+        pageSourceCache?.let { if (it.first == url) return it.second }
+        if (!url.startsWith("http://") && !url.startsWith("https://")) return null
+        val request = try {
+            Request.Builder()
+                .url(url)
+                .header("User-Agent", browserUserAgent())
+                .header("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8")
+                .apply {
+                    CookieManager.getInstance().getCookie(url)?.let { header("Cookie", it) }
+                }
+                .build()
+        } catch (e: Exception) {
+            return null
+        }
+        return withContext(Dispatchers.IO) {
+            try {
+                sourceClient.newCall(request).execute().use { resp ->
+                    if (!resp.isSuccessful) return@use null
+                    val contentType = resp.header("Content-Type").orEmpty().lowercase()
+                    if (BINARY_TYPE_PREFIXES.any { contentType.startsWith(it) }) return@use null
+                    val text = resp.body?.string() ?: return@use null
+                    val capped = if (text.length > MAX_SOURCE_CHARS) text.take(MAX_SOURCE_CHARS) else text
+                    pageSourceCache = url to capped
+                    capped
+                }
+            } catch (e: Exception) {
+                null
+            }
+        }
+    }
+
+    private suspend fun browserUserAgent(): String =
+        withContext(Dispatchers.Main) {
+            try {
+                browserState.ebWebView.settings.userAgentString
+            } catch (e: Exception) {
+                null
+            }
+        } ?: WebSettings.getDefaultUserAgent(context)
 
     // ── Domain config ───────────────────────────────────────────────────
 
@@ -171,6 +281,89 @@ class BrowserToolsImpl(
         ttsViewModel.readArticle(text, title)
     }
 
+    // ── EPUB export ─────────────────────────────────────────────────────
+
+    private val epubManager: EpubManager by lazy { EpubManager(context) }
+
+    override suspend fun saveEpub(
+        bookName: String,
+        chapters: List<BrowserTools.EpubChapterSpec>,
+        onChapterLoaded: (Int, Int, String) -> Unit,
+    ): String? {
+        if (chapters.isEmpty()) return null
+
+        val contents = mutableListOf<EpubChapterContent>()
+        chapters.forEachIndexed { index, spec ->
+            if (!openUrlInBg(spec.url)) return@forEachIndexed
+            val wv = bgWebView ?: return@forEachIndexed
+            val loaded = withContext(Dispatchers.Main) {
+                withTimeoutOrNull(READER_EXTRACT_TIMEOUT_MS) { wv.getRawReaderHtml() }
+                    ?.let { it to wv.title.orEmpty() }
+            } ?: return@forEachIndexed
+            val (html, pageTitle) = loaded
+            if (html.isBlank()) return@forEachIndexed
+            val title = spec.title.ifBlank { pageTitle.ifBlank { spec.url } }
+            contents += EpubChapterContent(title, html, spec.url)
+            onChapterLoaded(index + 1, chapters.size, title)
+        }
+        if (contents.isEmpty()) return null
+
+        val safeName = bookName.replace(Regex("[\\\\/:*?\"<>|]"), "_").take(60)
+        val (fileUri, savedLocation) = createEpubDownloadUri(safeName) ?: return null
+        if (!epubManager.saveEpubDirectly(fileUri, bookName, contents)) {
+            // Don't leave a 0-byte MediaStore entry in Downloads on failure.
+            try {
+                context.contentResolver.delete(fileUri, null, null)
+            } catch (_: Exception) {
+            }
+            return null
+        }
+
+        val bookUri = fileUri.toString()
+        if (config.savedEpubFileInfos.none { it.uri == bookUri }) {
+            config.addSavedEpubFile(SavedFileInfo(bookName, bookUri))
+        }
+        return savedLocation
+    }
+
+    /** Creates a writable destination for a new EPUB plus its human-readable location.
+     *  MediaStore Downloads on Q+; on older devices the public Downloads folder when
+     *  the legacy storage permission is granted, else app-private storage (the book is
+     *  still registered in EinkBro's saved-EPUB list, so the user can open it there). */
+    private fun createEpubDownloadUri(fileName: String): Pair<Uri, String>? = try {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            val contentValues = ContentValues().apply {
+                put(MediaStore.MediaColumns.DISPLAY_NAME, "$fileName.epub")
+                put(MediaStore.MediaColumns.MIME_TYPE, Constants.MIME_TYPE_EPUB)
+                put(MediaStore.MediaColumns.RELATIVE_PATH, Environment.DIRECTORY_DOWNLOADS)
+            }
+            context.contentResolver
+                .insert(MediaStore.Downloads.EXTERNAL_CONTENT_URI, contentValues)
+                ?.let { it to "${Environment.DIRECTORY_DOWNLOADS}/$fileName.epub" }
+        } else {
+            val canWritePublic = ContextCompat.checkSelfPermission(
+                context, Manifest.permission.WRITE_EXTERNAL_STORAGE
+            ) == PackageManager.PERMISSION_GRANTED
+            val dir = if (canWritePublic) {
+                Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS)
+            } else {
+                context.getExternalFilesDir(Environment.DIRECTORY_DOWNLOADS) ?: context.filesDir
+            }
+            if (!dir.exists()) dir.mkdirs()
+            var file = File(dir, "$fileName.epub")
+            var suffix = 1
+            while (file.exists()) {
+                file = File(dir, "$fileName (${suffix++}).epub")
+            }
+            val location = if (canWritePublic) "${Environment.DIRECTORY_DOWNLOADS}/${file.name}"
+            else "EinkBro's saved EPUB list (${file.name})"
+            Uri.fromFile(file) to location
+        }
+    } catch (e: Exception) {
+        android.util.Log.e("BrowserToolsImpl", "createEpubDownloadUri failed", e)
+        null
+    }
+
     // ── Progress reporting ──────────────────────────────────────────────
 
     override fun info(text: String) =
@@ -212,5 +405,19 @@ class BrowserToolsImpl(
 
     companion object {
         private const val PAGE_LOAD_TIMEOUT_MS = 30_000L
+        private const val JS_EVAL_TIMEOUT_MS = 10_000L
+
+        // Reader-mode extraction goes through the JS bridge, whose callback is not
+        // guaranteed to fire on every page — never wait on it unbounded.
+        private const val READER_EXTRACT_TIMEOUT_MS = 15_000L
+
+        // Memory guard for fetched page sources; windowed tool reads never need more.
+        private const val MAX_SOURCE_CHARS = 2_000_000
+
+        // Content types that would decode to garbage if treated as page source.
+        private val BINARY_TYPE_PREFIXES = listOf(
+            "image/", "video/", "audio/", "font/",
+            "application/octet-stream", "application/pdf", "application/zip",
+        )
     }
 }

--- a/app/src/main/java/info/plateaukao/einkbro/task/ToolTextWindow.kt
+++ b/app/src/main/java/info/plateaukao/einkbro/task/ToolTextWindow.kt
@@ -1,0 +1,40 @@
+package info.plateaukao.einkbro.task
+
+/**
+ * Windows large agent-tool results instead of blindly truncating them. The returned
+ * window is prefixed with a `[chars a..b of N]` header so the model knows where it is
+ * in the document and how to page for more.
+ */
+object ToolTextWindow {
+
+    const val DEFAULT_SEARCH_PRE_CONTEXT_CHARS = 200
+
+    /**
+     * Returns the window of [content] starting at [offset], capped to [maxChars].
+     * When [search] is given, jumps to its first occurrence at/after [offset]
+     * (case-insensitive) and starts [searchPreContextChars] before the match so the
+     * model sees the enclosing markup; returns a `not found` message if absent.
+     */
+    fun window(
+        content: String,
+        maxChars: Int,
+        offset: Int = 0,
+        search: String? = null,
+        searchPreContextChars: Int = DEFAULT_SEARCH_PRE_CONTEXT_CHARS,
+    ): String {
+        val total = content.length
+        var start = offset.coerceIn(0, total)
+        if (!search.isNullOrBlank()) {
+            val idx = content.indexOf(search, start, ignoreCase = true)
+            if (idx < 0) {
+                return "not found: \"$search\" (searched from offset $start; document is $total chars)"
+            }
+            // Cap pre-context to half the window so the match itself always fits.
+            val preContext = searchPreContextChars.coerceAtMost(maxChars / 2)
+            start = (idx - preContext).coerceAtLeast(0)
+        }
+        val end = (start + maxChars).coerceAtMost(total)
+        val more = if (end < total) "; continue with offset=$end" else "; end of document"
+        return "[chars $start..$end of $total$more]\n" + content.substring(start, end)
+    }
+}

--- a/app/src/main/java/info/plateaukao/einkbro/view/EBWebView.kt
+++ b/app/src/main/java/info/plateaukao/einkbro/view/EBWebView.kt
@@ -43,11 +43,11 @@ import info.plateaukao.einkbro.util.PdfDocumentAdapter
 import info.plateaukao.einkbro.viewmodel.TRANSLATE_API
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.suspendCancellableCoroutine
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 import java.io.ByteArrayOutputStream
 import kotlin.coroutines.resume
-import kotlin.coroutines.suspendCoroutine
 
 
 
@@ -624,9 +624,11 @@ open class EBWebView(
         webViewCallback?.updateTitle(album.albumTitle)
     }
 
-    // Guards the postDelayed callbacks above: touching a destroyed WebView is
-    // undefined behavior on older vendor builds.
-    private var isWebViewDestroyed = false
+    // Guards the postDelayed callbacks above (and agent tools holding weak references
+    // to this tab): touching a destroyed WebView is undefined behavior on older vendor
+    // builds.
+    var isWebViewDestroyed = false
+        private set
 
     override fun destroy() {
         isWebViewDestroyed = true
@@ -691,7 +693,11 @@ open class EBWebView(
     fun selectLinkText(point: Point) = touchSimulator.selectLinkText(point)
 
     var rawHtmlCache: String? = null
-    suspend fun getRawReaderHtml() = suspendCoroutine { continuation ->
+
+    // Cancellable so callers can wrap in withTimeoutOrNull: the JS bridge callback is
+    // not guaranteed to fire (CSP-blocked injection, page script errors), and a plain
+    // suspendCoroutine would ignore the timeout's cancellation and hang forever.
+    suspend fun getRawReaderHtml() = suspendCancellableCoroutine<String> { continuation ->
         if (isPlainText && rawHtmlCache != null) {
             continuation.resume(rawHtmlCache!!)
         } else if (!isReaderModeOn && !isTranslatePage) {
@@ -700,7 +706,7 @@ open class EBWebView(
                 val processedHtml = HelperUnit.unescapeJava(html)
                 val rawHtml = processedHtml.substring(1, processedHtml.length - 1)
                 rawHtmlCache = rawHtml
-                continuation.resume(rawHtml)
+                if (continuation.isActive) continuation.resume(rawHtml)
             }
         } else {
             evaluateJavascript(
@@ -709,24 +715,24 @@ open class EBWebView(
                 val processedHtml = HelperUnit.unescapeJava(html)
                 val rawHtml = processedHtml.substring(1, processedHtml.length - 1)
                 rawHtmlCache = rawHtmlCache ?: rawHtml
-                continuation.resume(rawHtml)
+                if (continuation.isActive) continuation.resume(rawHtml)
             }
         }
     }
 
-    suspend fun getRawText() = suspendCoroutine<String> { continuation ->
+    suspend fun getRawText() = suspendCancellableCoroutine<String> { continuation ->
         if (dualCaption != null) {
             continuation.resume(DualCaptionProcessor().convertToHtml(dualCaption ?: ""))
         } else if (!isReaderModeOn) {
             jsBridge.evaluateMozReaderModeJs {
                 jsBridge.getReaderModeBodyText(config.display.readerKeepExtraContent) { text ->
                     if (text == "null") {
-                        continuation.resume("")
+                        if (continuation.isActive) continuation.resume("")
                     } else {
                         val processedText = if (text.startsWith("\"") && text.endsWith("\"")) {
                             text.substring(1, text.length - 2)
                         } else text
-                        continuation.resume(processedText)
+                        if (continuation.isActive) continuation.resume(processedText)
                     }
                 }
             }
@@ -737,7 +743,7 @@ open class EBWebView(
                 val processedText = if (text.startsWith("\"") && text.endsWith("\"")) {
                     text.substring(1, text.length - 2)
                 } else text
-                continuation.resume(processedText)
+                if (continuation.isActive) continuation.resume(processedText)
             }
         }
     }

--- a/app/src/test/java/info/plateaukao/einkbro/task/ToolTextWindowTest.kt
+++ b/app/src/test/java/info/plateaukao/einkbro/task/ToolTextWindowTest.kt
@@ -1,0 +1,79 @@
+package info.plateaukao.einkbro.task
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ToolTextWindowTest {
+
+    @Test
+    fun `short document is returned whole with end-of-document header`() {
+        val result = ToolTextWindow.window("hello world", maxChars = 100)
+        assertEquals("[chars 0..11 of 11; end of document]\nhello world", result)
+    }
+
+    @Test
+    fun `long document is windowed and header tells the next offset`() {
+        val content = "a".repeat(50)
+        val result = ToolTextWindow.window(content, maxChars = 20)
+        assertEquals("[chars 0..20 of 50; continue with offset=20]\n" + "a".repeat(20), result)
+    }
+
+    @Test
+    fun `offset pages through the document`() {
+        val content = "0123456789".repeat(5) // 50 chars
+        val result = ToolTextWindow.window(content, maxChars = 20, offset = 20)
+        assertEquals("[chars 20..40 of 50; continue with offset=40]\n" + content.substring(20, 40), result)
+    }
+
+    @Test
+    fun `offset past end returns empty window instead of crashing`() {
+        val result = ToolTextWindow.window("short", maxChars = 10, offset = 999)
+        assertEquals("[chars 5..5 of 5; end of document]\n", result)
+    }
+
+    @Test
+    fun `negative offset is clamped to zero`() {
+        val result = ToolTextWindow.window("hello", maxChars = 10, offset = -5)
+        assertTrue(result.startsWith("[chars 0..5 of 5"))
+    }
+
+    @Test
+    fun `search jumps to match with pre-context`() {
+        val content = "x".repeat(1000) + "<div class=\"ad-banner\">buy now</div>" + "y".repeat(1000)
+        val result = ToolTextWindow.window(content, maxChars = 100, search = "ad-banner")
+        // match at 1012; pre-context capped to maxChars/2 = 50, so window starts at 962
+        assertTrue(result.startsWith("[chars 962.."))
+        assertTrue(result.contains("ad-banner"))
+    }
+
+    @Test
+    fun `search is case-insensitive`() {
+        val content = "x".repeat(300) + "COOKIE-CONSENT" + "y".repeat(300)
+        val result = ToolTextWindow.window(content, maxChars = 100, search = "cookie-consent")
+        assertTrue(result.contains("COOKIE-CONSENT"))
+    }
+
+    @Test
+    fun `search respects starting offset to find later occurrences`() {
+        val content = "match" + "x".repeat(500) + "match" + "y".repeat(100)
+        val result = ToolTextWindow.window(content, maxChars = 50, offset = 100, search = "match")
+        // second occurrence is at 505; pre-context capped to 25, so window starts at 480
+        assertTrue(result.startsWith("[chars 480.."))
+        assertTrue(result.contains("match"))
+    }
+
+    @Test
+    fun `search miss reports not found with document size`() {
+        val result = ToolTextWindow.window("hello world", maxChars = 100, search = "absent")
+        assertEquals("not found: \"absent\" (searched from offset 0; document is 11 chars)", result)
+    }
+
+    @Test
+    fun `search near document start clamps pre-context to zero`() {
+        val content = "needle" + "x".repeat(500)
+        val result = ToolTextWindow.window(content, maxChars = 50, search = "needle")
+        assertTrue(result.startsWith("[chars 0.."))
+        assertTrue(result.contains("needle"))
+    }
+}


### PR DESCRIPTION
Expands the free-form LLM agent's tool surface so it can act on pages precisely instead of guessing from truncated reader-mode text.

## New agent tools
- **`read_page_source`** — downloads the real served HTML (view-source equivalent) via OkHttp with the WebView's cookies + user agent, cached per URL. Ground truth for CSS/DOM selectors.
- **Windowed tool results** (`ToolTextWindow`) — replaces blind 8k truncation with `offset` paging and case-insensitive `search`-to-element, prefixed with a `[chars a..b of N]` header. Applies to `read_page_source`, `read_initial_html`, `read_initial_page`, `read_current_page`.
- **`run_javascript`** — eval JS on the live originating tab (test a removal selector before persisting it — the user sees it work) or the off-screen WebView (extract structured data). 10s timeout, destroyed-tab guarded.
- **`web_search`** — query the user's configured search engine off-screen and return the result links.
- **`save_epub`** — fetch chapter URLs off-screen, extract reader HTML, and write a multi-chapter EPUB to Downloads (non-interactive `EpubManager.saveEpubDirectly`).

## Supporting changes
- `EBWebView.getRawReaderHtml`/`getRawText` are now cancellable so reader extraction can be bounded by `withTimeoutOrNull`.
- `EBWebView` exposes `isWebViewDestroyed`; `InitialPageSnapshot` carries a `WeakReference` to the origin tab.
- Unit tests cover the windowing logic (offset clamping, paging, search hit/miss, pre-context clamping).

## Verification
Driven end-to-end on an emulator (Pixel 7 API 34):
- Ad-banner removal: agent read real source + rendered DOM via `search`, tested the removal on the live tab, persisted it, and after a fresh reload both banners were gone.
- `save_epub`: three local articles produced a well-formed `application/epub+zip` archive with correct container/manifest/nav and one chapter per article.
- `web_search`: returned real result links, agent visited the page it picked, read it, and answered a factual lookup correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)