### PR TITLE
Add double-click volume key as Back (opt-in)

### DIFF
--- a/app/src/main/java/info/plateaukao/einkbro/activity/KeyHandler.kt
+++ b/app/src/main/java/info/plateaukao/einkbro/activity/KeyHandler.kt
@@ -188,6 +188,11 @@ class KeyHandler(
     private val scope = CoroutineScope(Dispatchers.Main + SupervisorJob())
     private var reenableJob: Job? = null
 
+    // Double-click-for-back: a single tap's page turn is deferred by this window
+    // so a second tap of the same key can be caught and treated as "back" instead.
+    private var pendingPageTurnJob: Job? = null
+    private var pendingPageTurnKeyCode: Int = 0
+
     private fun scheduleReenableVolumePageTurn() {
         reenableJob?.cancel()
         reenableJob = scope.launch {
@@ -202,9 +207,44 @@ class KeyHandler(
         scope.cancel()
     }
 
+    // Returns true if this press was consumed by the double-click gate.
+    // First tap of a key schedules a deferred page turn; a second tap of the
+    // same key within the window cancels it and goes back instead.
+    private fun handleVolumeDoubleClick(keyCode: Int): Boolean {
+        val pending = pendingPageTurnJob
+        if (pending?.isActive == true && pendingPageTurnKeyCode == keyCode) {
+            pending.cancel()
+            pendingPageTurnJob = null
+            keyCallback.handleBackKey()
+            return true
+        }
+        pendingPageTurnKeyCode = keyCode
+        pendingPageTurnJob = scope.launch {
+            delay(DOUBLE_CLICK_WINDOW_MS)
+            performVolumePageTurn(keyCode)
+            pendingPageTurnJob = null
+        }
+        return true
+    }
+
+    private fun cancelPendingPageTurn() {
+        pendingPageTurnJob?.cancel()
+        pendingPageTurnJob = null
+    }
+
+    private fun performVolumePageTurn(keyCode: Int) {
+        val pageUp = when (keyCode) {
+            KeyEvent.KEYCODE_VOLUME_DOWN -> ebWebView.isVerticalRead
+            else -> !ebWebView.isVerticalRead
+        }
+        if (pageUp) ebWebView.pageUpWithNoAnimation() else ebWebView.pageDownWithNoAnimation()
+    }
+
     fun onKeyLongPress(keyCode: Int, event: KeyEvent): Boolean {
         if (keyCode == KeyEvent.KEYCODE_VOLUME_UP || keyCode == KeyEvent.KEYCODE_VOLUME_DOWN) {
             if (config.touch.volumePageTurn) {
+                // A long press is not a double tap: drop any deferred page turn.
+                cancelPendingPageTurn()
                 isVolumeLongPress = true
                 isVolumeTemporarilyDisabled = true
                 scheduleReenableVolumePageTurn()
@@ -238,6 +278,12 @@ class KeyHandler(
         audioManager.adjustStreamVolume(AudioManager.STREAM_MUSIC, direction, AudioManager.FLAG_SHOW_UI)
     }
 
+    companion object {
+        // Gap allowed between the two taps of a double-click. This is also the
+        // delay added to a single tap's page turn when the feature is enabled.
+        private const val DOUBLE_CLICK_WINDOW_MS = 250L
+    }
+
     private fun handleVolumeDownKey(event: KeyEvent): Boolean {
         if (config.touch.volumePageTurn) {
             if (isVolumeTemporarilyDisabled) {
@@ -247,6 +293,9 @@ class KeyHandler(
             if (event.repeatCount == 0) {
                 isVolumeLongPress = false
                 event.startTracking()
+                if (config.touch.volumeDoubleClickBack) {
+                    return handleVolumeDoubleClick(KeyEvent.KEYCODE_VOLUME_DOWN)
+                }
                 if (ebWebView.isVerticalRead) {
                     ebWebView.pageUpWithNoAnimation()
                 } else {
@@ -254,6 +303,8 @@ class KeyHandler(
                 }
                 return true
             } else {
+                // Held down: abandon any pending single-tap page turn.
+                cancelPendingPageTurn()
                 if (isVolumeLongPress) {
                     adjustVolume(KeyEvent.KEYCODE_VOLUME_DOWN)
                     return true
@@ -273,6 +324,9 @@ class KeyHandler(
             if (event.repeatCount == 0) {
                 isVolumeLongPress = false
                 event.startTracking()
+                if (config.touch.volumeDoubleClickBack) {
+                    return handleVolumeDoubleClick(KeyEvent.KEYCODE_VOLUME_UP)
+                }
                 if (ebWebView.isVerticalRead) {
                     ebWebView.pageDownWithNoAnimation()
                 } else {
@@ -280,6 +334,8 @@ class KeyHandler(
                 }
                 return true
             } else {
+                // Held down: abandon any pending single-tap page turn.
+                cancelPendingPageTurn()
                 if (isVolumeLongPress) {
                     adjustVolume(KeyEvent.KEYCODE_VOLUME_UP)
                     return true

--- a/app/src/main/java/info/plateaukao/einkbro/activity/KeyHandler.kt
+++ b/app/src/main/java/info/plateaukao/einkbro/activity/KeyHandler.kt
@@ -42,8 +42,8 @@ class KeyHandler(
                 return config.touch.useUpDownPageTurn
             }
 
-            KeyEvent.KEYCODE_VOLUME_DOWN -> return handleVolumeDownKey(event)
-            KeyEvent.KEYCODE_VOLUME_UP -> return handleVolumeUpKey(event)
+            KeyEvent.KEYCODE_VOLUME_DOWN, KeyEvent.KEYCODE_VOLUME_UP ->
+                return handleVolumeKey(keyCode, event)
             KeyEvent.KEYCODE_MENU -> {
                 keyCallback.showMenuDialog()
                 return true
@@ -188,10 +188,13 @@ class KeyHandler(
     private val scope = CoroutineScope(Dispatchers.Main + SupervisorJob())
     private var reenableJob: Job? = null
 
-    // Double-click-for-back: a single tap's page turn is deferred by this window
-    // so a second tap of the same key can be caught and treated as "back" instead.
-    private var pendingPageTurnJob: Job? = null
-    private var pendingPageTurnKeyCode: Int = 0
+    // Double-click-for-back: a short press schedules its page turn on key-up,
+    // deferred by DOUBLE_CLICK_WINDOW_MS, so a second press of the same key can
+    // cancel it and go back instead. Scheduling on key-up (not key-down) matters:
+    // the long-press callback only fires after ~400-500ms, so a turn deferred
+    // from key-down would fire mid-hold before it could be cancelled.
+    private val pendingPageTurnJobs = mutableMapOf<Int, Job>()
+    private var backHandledKeyCode: Int? = null
 
     private fun scheduleReenableVolumePageTurn() {
         reenableJob?.cancel()
@@ -207,29 +210,31 @@ class KeyHandler(
         scope.cancel()
     }
 
-    // Returns true if this press was consumed by the double-click gate.
-    // First tap of a key schedules a deferred page turn; a second tap of the
-    // same key within the window cancels it and goes back instead.
-    private fun handleVolumeDoubleClick(keyCode: Int): Boolean {
-        val pending = pendingPageTurnJob
-        if (pending?.isActive == true && pendingPageTurnKeyCode == keyCode) {
+    // A second press of the same key while its page turn is still pending is a
+    // double-click: drop the turn and go back. A first press just consumes the
+    // event; its page turn is scheduled when the key is released.
+    private fun handleVolumeDoubleClickDown(keyCode: Int): Boolean {
+        val pending = pendingPageTurnJobs.remove(keyCode)
+        if (pending?.isActive == true) {
             pending.cancel()
-            pendingPageTurnJob = null
+            backHandledKeyCode = keyCode
             keyCallback.handleBackKey()
-            return true
-        }
-        pendingPageTurnKeyCode = keyCode
-        pendingPageTurnJob = scope.launch {
-            delay(DOUBLE_CLICK_WINDOW_MS)
-            performVolumePageTurn(keyCode)
-            pendingPageTurnJob = null
         }
         return true
     }
 
-    private fun cancelPendingPageTurn() {
-        pendingPageTurnJob?.cancel()
-        pendingPageTurnJob = null
+    private fun scheduleDeferredPageTurn(keyCode: Int) {
+        pendingPageTurnJobs.remove(keyCode)?.cancel()
+        pendingPageTurnJobs[keyCode] = scope.launch {
+            delay(DOUBLE_CLICK_WINDOW_MS)
+            performVolumePageTurn(keyCode)
+            pendingPageTurnJobs.remove(keyCode)
+        }
+    }
+
+    private fun cancelPendingPageTurns() {
+        pendingPageTurnJobs.values.forEach { it.cancel() }
+        pendingPageTurnJobs.clear()
     }
 
     private fun performVolumePageTurn(keyCode: Int) {
@@ -243,8 +248,9 @@ class KeyHandler(
     fun onKeyLongPress(keyCode: Int, event: KeyEvent): Boolean {
         if (keyCode == KeyEvent.KEYCODE_VOLUME_UP || keyCode == KeyEvent.KEYCODE_VOLUME_DOWN) {
             if (config.touch.volumePageTurn) {
-                // A long press is not a double tap: drop any deferred page turn.
-                cancelPendingPageTurn()
+                // Page turning is pausing: drop any page turn still pending
+                // from an earlier tap (possibly of the other volume key).
+                cancelPendingPageTurns()
                 isVolumeLongPress = true
                 isVolumeTemporarilyDisabled = true
                 scheduleReenableVolumePageTurn()
@@ -260,8 +266,15 @@ class KeyHandler(
     fun onKeyUp(keyCode: Int, event: KeyEvent): Boolean {
         if (keyCode == KeyEvent.KEYCODE_VOLUME_UP || keyCode == KeyEvent.KEYCODE_VOLUME_DOWN) {
             if (config.touch.volumePageTurn) {
+                val wasBackHandled = backHandledKeyCode == keyCode
+                if (wasBackHandled) backHandledKeyCode = null
+                val wasLongPress = isVolumeLongPress
                 isVolumeLongPress = false
-                return !isVolumeTemporarilyDisabled
+                if (isVolumeTemporarilyDisabled) return false
+                if (config.touch.volumeDoubleClickBack && !wasBackHandled && !wasLongPress) {
+                    scheduleDeferredPageTurn(keyCode)
+                }
+                return true
             }
         }
         return false
@@ -279,70 +292,31 @@ class KeyHandler(
     }
 
     companion object {
-        // Gap allowed between the two taps of a double-click. This is also the
-        // delay added to a single tap's page turn when the feature is enabled.
+        // How long after releasing a volume key a second press still counts as
+        // a double-click. This is also the delay added to a single tap's page
+        // turn when the feature is enabled. Must stay well below the system
+        // long-press timeout so a double-click can't be mistaken for a hold.
         private const val DOUBLE_CLICK_WINDOW_MS = 250L
     }
 
-    private fun handleVolumeDownKey(event: KeyEvent): Boolean {
-        if (config.touch.volumePageTurn) {
-            if (isVolumeTemporarilyDisabled) {
-                if (event.repeatCount == 0) extendVolumeDisablePeriod()
-                return false
-            }
-            if (event.repeatCount == 0) {
-                isVolumeLongPress = false
-                event.startTracking()
-                if (config.touch.volumeDoubleClickBack) {
-                    return handleVolumeDoubleClick(KeyEvent.KEYCODE_VOLUME_DOWN)
-                }
-                if (ebWebView.isVerticalRead) {
-                    ebWebView.pageUpWithNoAnimation()
-                } else {
-                    ebWebView.pageDownWithNoAnimation()
-                }
-                return true
-            } else {
-                // Held down: abandon any pending single-tap page turn.
-                cancelPendingPageTurn()
-                if (isVolumeLongPress) {
-                    adjustVolume(KeyEvent.KEYCODE_VOLUME_DOWN)
-                    return true
-                }
-                return true
-            }
+    private fun handleVolumeKey(keyCode: Int, event: KeyEvent): Boolean {
+        if (!config.touch.volumePageTurn) return false
+        if (isVolumeTemporarilyDisabled) {
+            if (event.repeatCount == 0) extendVolumeDisablePeriod()
+            return false
         }
-        return false
-    }
-
-    private fun handleVolumeUpKey(event: KeyEvent): Boolean {
-        if (config.touch.volumePageTurn) {
-            if (isVolumeTemporarilyDisabled) {
-                if (event.repeatCount == 0) extendVolumeDisablePeriod()
-                return false
+        if (event.repeatCount == 0) {
+            isVolumeLongPress = false
+            event.startTracking()
+            if (config.touch.volumeDoubleClickBack) {
+                return handleVolumeDoubleClickDown(keyCode)
             }
-            if (event.repeatCount == 0) {
-                isVolumeLongPress = false
-                event.startTracking()
-                if (config.touch.volumeDoubleClickBack) {
-                    return handleVolumeDoubleClick(KeyEvent.KEYCODE_VOLUME_UP)
-                }
-                if (ebWebView.isVerticalRead) {
-                    ebWebView.pageDownWithNoAnimation()
-                } else {
-                    ebWebView.pageUpWithNoAnimation()
-                }
-                return true
-            } else {
-                // Held down: abandon any pending single-tap page turn.
-                cancelPendingPageTurn()
-                if (isVolumeLongPress) {
-                    adjustVolume(KeyEvent.KEYCODE_VOLUME_UP)
-                    return true
-                }
-                return true
-            }
+            performVolumePageTurn(keyCode)
+            return true
         }
-        return false
+        if (isVolumeLongPress) {
+            adjustVolume(keyCode)
+        }
+        return true
     }
 }

--- a/app/src/main/java/info/plateaukao/einkbro/preference/TouchConfig.kt
+++ b/app/src/main/java/info/plateaukao/einkbro/preference/TouchConfig.kt
@@ -16,6 +16,7 @@ class TouchConfig(private val sp: SharedPreferences) {
     )
     var touchAreaHint by BooleanPreference(sp, K_TOUCH_HINT, true)
     var volumePageTurn by BooleanPreference(sp, K_VOLUME_PAGE_TURN, true)
+    var volumeDoubleClickBack by BooleanPreference(sp, K_VOLUME_DOUBLE_CLICK_BACK, false)
     var switchTouchAreaAction by BooleanPreference(sp, K_TOUCH_AREA_ACTION_SWITCH, false)
     var longClickAsArrowKey by BooleanPreference(sp, K_TOUCH_AREA_ARROW_KEY, false)
     var hideTouchAreaWhenInput by BooleanPreference(sp, K_TOUCH_AREA_HIDE_WHEN_INPUT, false)
@@ -74,6 +75,7 @@ class TouchConfig(private val sp: SharedPreferences) {
         const val K_ENABLE_TOUCH = "sp_enable_touch"
         const val K_TOUCH_HINT = "sp_touch_area_hint"
         const val K_VOLUME_PAGE_TURN = "volume_page_turn"
+        const val K_VOLUME_DOUBLE_CLICK_BACK = "sp_volume_double_click_back"
         const val K_UPDOWN_PAGE_TURN = "sp_useUpDownForPageTurn"
         const val K_MULTITOUCH = "sp_multitouch"
         const val K_TOUCH_AREA_OFFSET = "sp_touch_area_offset"

--- a/app/src/main/java/info/plateaukao/einkbro/setting/screens/GestureSettings.kt
+++ b/app/src/main/java/info/plateaukao/einkbro/setting/screens/GestureSettings.kt
@@ -56,6 +56,13 @@ fun buildGestureSettingItems(deps: SettingScreenDeps): List<SettingItemInterface
             config.touch::volumePageTurn,
             span = 2,
         ),
+        BooleanSettingItem(
+            R.string.volume_double_click_back,
+            0,
+            R.string.volume_double_click_back_summary,
+            config.touch::volumeDoubleClickBack,
+            span = 2,
+        ),
         DividerSettingItem(R.string.setting_multitouch_use_title),
         BooleanSettingItem(
             R.string.setting_multitouch_use_title,

--- a/app/src/main/res/values-af/strings.xml
+++ b/app/src/main/res/values-af/strings.xml
@@ -533,6 +533,8 @@
     <string name="volume_page_turn_summary">Gebruik volume op/af-sleutels om bladsye om te blaai</string>
     <string name="volume_page_turn_paused">Volume-bladsyomdraai gepauzeer vir 5 sekondes</string>
     <string name="volume_page_turn_resumed">Volume-bladsyomdraai hervat</string>
+    <string name="volume_double_click_back">Dubbelklik vir terug</string>
+    <string name="volume_double_click_back_summary">Dubbeltik \'n volumesleutel om terug te gaan; \'n enkele tik blaai die bladsy na \'n kort vertraging om. Vereis omblaai met volumesleutels.</string>
     <string name="web_content_processing">Webinhoudverwerking</string>
     <string name="web_processing_gpt_type">KI-enjin vir bladsygesprek</string>
     <string name="setting_title_default_ai_engine">Verstek KI-enjin</string>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -243,6 +243,8 @@
     <string name="volume_page_turn_summary">استخدم مفتاحَي رفع/خفض الصوت لتقليب الصفحات</string>
     <string name="volume_page_turn_paused">تقليب الصفحات بزر الصوت متوقف لمدة 5 ثوانٍ</string>
     <string name="volume_page_turn_resumed">تم استئناف تقليب الصفحات بزر الصوت</string>
+    <string name="volume_double_click_back">نقرة مزدوجة للرجوع</string>
+    <string name="volume_double_click_back_summary">انقر نقرًا مزدوجًا على مفتاح الصوت للرجوع؛ النقرة الواحدة تقلب الصفحة بعد تأخير قصير. يتطلب تفعيل تقليب الصفحات بمفاتيح الصوت.</string>
     <string name="folder_name">اسم مجلد الإشارات المرجعية</string>
     <string name="folder_name_description">أدخل اسم مجلد الإشارات المرجعية</string>
     <string name="setting_title_export_bookmarks">تصدير الإشارات المرجعية</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -210,6 +210,8 @@
     <string name="volume_page_turn_summary">Useu les tecles de volum per passar pàgines</string>
     <string name="volume_page_turn_paused">Pas de pàgina per volum pausat durant 5 segons</string>
     <string name="volume_page_turn_resumed">Pas de pàgina per volum reprès</string>
+    <string name="volume_double_click_back">Doble clic per tornar enrere</string>
+    <string name="volume_double_click_back_summary">Toqueu dues vegades una tecla de volum per tornar enrere; un sol toc passa la pàgina després d\'un breu retard. Requereix passar pàgines amb les tecles de volum.</string>
     <string name="folder_name">Nom de la carpeta d\'adreces d\'interès</string>
     <string name="folder_name_description">Introduïu el nom de la carpeta d\'adreces d\'interès</string>
     <string name="setting_title_export_bookmarks">Exportar adreces d\'interès</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -239,6 +239,8 @@
     <string name="volume_page_turn_summary">Otáčejte stránky tlačítky hlasitosti</string>
     <string name="volume_page_turn_paused">Otáčení stránek tlačítky hlasitosti pozastaveno na 5 sekund</string>
     <string name="volume_page_turn_resumed">Otáčení stránek tlačítky hlasitosti obnoveno</string>
+    <string name="volume_double_click_back">Dvojité stisknutí pro zpět</string>
+    <string name="volume_double_click_back_summary">Dvojím stisknutím tlačítka hlasitosti přejdete zpět; jedno stisknutí otočí stránku po krátké prodlevě. Vyžaduje otáčení stránek tlačítky hlasitosti.</string>
     <string name="folder_name">Název složky záložek</string>
     <string name="folder_name_description">Zadejte název složky záložek</string>
     <string name="setting_title_export_bookmarks">Exportovat záložky</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -532,6 +532,8 @@
     <string name="volume_page_turn_summary">Brug lydstyrketasterne til at skifte side</string>
     <string name="volume_page_turn_paused">Sideskift med lydstyrketast sat på pause i 5 sekunder</string>
     <string name="volume_page_turn_resumed">Sideskift med lydstyrketast genoptaget</string>
+    <string name="volume_double_click_back">Dobbeltklik for tilbage</string>
+    <string name="volume_double_click_back_summary">Dobbelttryk på en lydstyrketast for at gå tilbage; et enkelt tryk skifter side efter en kort forsinkelse. Kræver sideskift med lydstyrketasterne.</string>
     <string name="web_content_processing">Webindholdsbehandling</string>
     <string name="web_processing_gpt_type">AI-motor til sidechat</string>
     <string name="setting_title_default_ai_engine">Standard AI-motor</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -220,6 +220,8 @@ Dies zu deaktivieren ist sicherer, schneller und spart Datenvolumen. Manche Inha
     <string name="volume_page_turn_summary">Seiten mit den Lautstärketasten umblättern</string>
     <string name="volume_page_turn_paused">Seitenumblättern mit Lautstärketaste für 5 Sekunden pausiert</string>
     <string name="volume_page_turn_resumed">Seitenumblättern mit Lautstärketaste fortgesetzt</string>
+    <string name="volume_double_click_back">Doppelklick für Zurück</string>
+    <string name="volume_double_click_back_summary">Doppeltippen auf eine Lautstärketaste geht zurück; einfaches Tippen blättert nach kurzer Verzögerung um. Erfordert Umblättern mit Lautstärketasten.</string>
     <string name="folder_name">Lesezeichen-Ordnername</string>
     <string name="folder_name_description">Lesezeichen-Ordnername eingeben</string>
     <string name="setting_title_export_bookmarks">Lesezeichen exportieren</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -243,6 +243,8 @@
     <string name="volume_page_turn_summary">Χρήση των πλήκτρων έντασης για αλλαγή σελίδας</string>
     <string name="volume_page_turn_paused">Η αλλαγή σελίδας με πλήκτρο έντασης παύει για 5 δευτερόλεπτα</string>
     <string name="volume_page_turn_resumed">Η αλλαγή σελίδας με πλήκτρο έντασης συνεχίστηκε</string>
+    <string name="volume_double_click_back">Διπλό πάτημα για επιστροφή</string>
+    <string name="volume_double_click_back_summary">Πατήστε δύο φορές ένα πλήκτρο έντασης για επιστροφή· ένα πάτημα αλλάζει σελίδα μετά από μικρή καθυστέρηση. Απαιτεί την αλλαγή σελίδας με τα πλήκτρα έντασης.</string>
     <string name="folder_name">Όνομα φακέλου σελιδοδεικτών</string>
     <string name="folder_name_description">Εισάγετε όνομα φακέλου σελιδοδεικτών</string>
     <string name="setting_title_export_bookmarks">Εξαγωγή σελιδοδεικτών</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -503,6 +503,8 @@
     <string name="reader_toolbar">Ajuste de barra de lectura</string>
     <string name="volume_page_turn_paused">Paso de página por volumen pausado durante 5 segundos</string>
     <string name="volume_page_turn_resumed">Paso de página por volumen reanudado</string>
+    <string name="volume_double_click_back">Doble clic para atrás</string>
+    <string name="volume_double_click_back_summary">Pulsa dos veces una tecla de volumen para ir atrás; una sola pulsación pasa la página tras un breve retardo. Requiere pasar páginas con las teclas de volumen.</string>
     <string name="toc_delete">Eliminar</string>
     <string name="gpt_scope">Alcance</string>
     <string name="gpt_scope_text_selection">Selección de texto</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -532,6 +532,8 @@
     <string name="volume_page_turn_summary">Käännä sivuja äänenvoimakkuusnäppäimillä</string>
     <string name="volume_page_turn_paused">Sivunvaihto äänenvoimakkuusnäppäimellä pysäytetty 5 sekunniksi</string>
     <string name="volume_page_turn_resumed">Sivunvaihto äänenvoimakkuusnäppäimellä jatkettu</string>
+    <string name="volume_double_click_back">Kaksoispainalluksella takaisin</string>
+    <string name="volume_double_click_back_summary">Paina äänenvoimakkuusnäppäintä kahdesti siirtyäksesi taaksepäin; yksi painallus kääntää sivun lyhyen viiveen jälkeen. Vaatii sivujen kääntämisen äänenvoimakkuusnäppäimillä.</string>
     <string name="web_content_processing">Verkkosisällön käsittely</string>
     <string name="web_processing_gpt_type">Tekoälymoottori sivukeskusteluun</string>
     <string name="setting_title_default_ai_engine">Oletusarvoinen tekoälymoottori</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -228,6 +228,8 @@
     <string name="volume_page_turn_summary">Utiliser les touches de volume pour changer de page</string>
     <string name="volume_page_turn_paused">Pagination par volume en pause pendant 5 secondes</string>
     <string name="volume_page_turn_resumed">Pagination par volume reprise</string>
+    <string name="volume_double_click_back">Double-clic pour revenir en arrière</string>
+    <string name="volume_double_click_back_summary">Appuyez deux fois sur une touche de volume pour revenir en arrière ; un appui simple tourne la page après un court délai. Nécessite le changement de page par les touches de volume.</string>
     <string name="folder_name">Nom du dossier de signets</string>
     <string name="folder_name_description">Saisir le nom du dossier de signets</string>
     <string name="setting_title_export_bookmarks">Exporter les signets</string>

--- a/app/src/main/res/values-he/strings.xml
+++ b/app/src/main/res/values-he/strings.xml
@@ -243,6 +243,8 @@
     <string name="volume_page_turn_summary">השתמשו במקשי עוצמת הקול כדי לדפדף בין הדפים</string>
     <string name="volume_page_turn_paused">הפיכת עמודים במקש עוצמה מושהית ל-5 שניות</string>
     <string name="volume_page_turn_resumed">הפיכת עמודים במקש עוצמה חודשה</string>
+    <string name="volume_double_click_back">לחיצה כפולה לחזרה</string>
+    <string name="volume_double_click_back_summary">הקישו פעמיים על מקש עוצמת הקול כדי לחזור אחורה; הקשה אחת מדפדפת עמוד לאחר השהיה קצרה. דורש דפדוף עמודים במקשי עוצמת הקול.</string>
     <string name="folder_name">שם תיקיית סימניות</string>
     <string name="folder_name_description">הזן שם תיקיית סימניות</string>
     <string name="setting_title_export_bookmarks">ייצוא סימניות</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -388,6 +388,8 @@
     <string name="volume_page_turn_summary">Lapozás a hangerőgombokkal</string>
     <string name="volume_page_turn_paused">Hangerőgombos lapozás szüneteltetve 5 másodpercre</string>
     <string name="volume_page_turn_resumed">Hangerőgombos lapozás folytatva</string>
+    <string name="volume_double_click_back">Dupla kattintás a visszalépéshez</string>
+    <string name="volume_double_click_back_summary">Koppintson duplán egy hangerőgombra a visszalépéshez; egyetlen koppintás rövid késleltetés után lapoz. A hangerőgombos lapozás bekapcsolása szükséges.</string>
     <string name="folder_name">Könyvjelző mappa neve</string>
     <string name="folder_name_description">Adja meg a könyvjelző mappa nevét</string>
     <string name="setting_title_export_bookmarks">Könyvjelzők exportálása</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -586,6 +586,8 @@
     <string name="vertical_line">Garis vertikal</string>
     <string name="volume_page_turn_paused">Balik halaman dengan tombol volume dijeda 5 detik</string>
     <string name="volume_page_turn_resumed">Balik halaman dengan tombol volume dilanjutkan</string>
+    <string name="volume_double_click_back">Klik dua kali untuk kembali</string>
+    <string name="volume_double_click_back_summary">Tekan tombol volume dua kali untuk kembali; sekali tekan membalik halaman setelah jeda singkat. Memerlukan pembalikan halaman dengan tombol volume.</string>
     <string name="web_content_processing">Pemrosesan Konten Web</string>
     <string name="web_processing_gpt_type">Mesin AI untuk obrolan halaman</string>
     <string name="setting_title_default_ai_engine">Mesin AI bawaan</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -219,6 +219,8 @@
     <string name="volume_page_turn_summary">Usa i tasti del volume per cambiare pagina</string>
     <string name="volume_page_turn_paused">Cambio pagina con volume in pausa per 5 secondi</string>
     <string name="volume_page_turn_resumed">Cambio pagina con volume ripreso</string>
+    <string name="volume_double_click_back">Doppio clic per tornare indietro</string>
+    <string name="volume_double_click_back_summary">Tocca due volte un tasto del volume per tornare indietro; un singolo tocco cambia pagina dopo un breve ritardo. Richiede il cambio pagina con i tasti del volume.</string>
     <string name="folder_name">Nome cartella segnalibri</string>
     <string name="folder_name_description">Inserisci il nome della cartella segnalibri</string>
     <string name="setting_title_export_bookmarks">Esporta segnalibri</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -531,6 +531,8 @@
     <string name="volume_page_turn_summary">音量キーでページをめくる</string>
     <string name="volume_page_turn_paused">音量キーページめくりを5秒間一時停止</string>
     <string name="volume_page_turn_resumed">音量キーページめくりを再開</string>
+    <string name="volume_double_click_back">ダブルクリックで戻る</string>
+    <string name="volume_double_click_back_summary">音量キーを2回押すと前のページに戻ります。1回押すと少し遅れてページをめくります。音量キーでのページめくりが有効になっている必要があります。</string>
     <string name="web_content_processing">ウェブコンテンツ処理</string>
     <string name="web_processing_gpt_type">ページチャット用AIエンジン</string>
     <string name="setting_title_default_ai_engine">デフォルトのAIエンジン</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -588,6 +588,8 @@
     <string name="vertical_line">세로선</string>
     <string name="volume_page_turn_paused">볼륨 키 페이지 넘기기가 5초간 일시 중지됨</string>
     <string name="volume_page_turn_resumed">볼륨 키 페이지 넘기기가 재개됨</string>
+    <string name="volume_double_click_back">두 번 눌러 뒤로 가기</string>
+    <string name="volume_double_click_back_summary">볼륨 키를 두 번 누르면 뒤로 이동합니다. 한 번 누르면 잠시 후 페이지를 넘깁니다. 볼륨 키 페이지 넘김이 켜져 있어야 합니다.</string>
     <string name="web_content_processing">웹 콘텐츠 처리</string>
     <string name="web_processing_gpt_type">페이지 채팅용 AI 엔진</string>
     <string name="setting_title_default_ai_engine">기본 AI 엔진</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -227,6 +227,8 @@
     <string name="volume_page_turn_summary">Gebruik de volumetoetsen om te bladeren</string>
     <string name="volume_page_turn_paused">Pagina omslaan met volumetoets 5 seconden gepauzeerd</string>
     <string name="volume_page_turn_resumed">Pagina omslaan met volumetoets hervat</string>
+    <string name="volume_double_click_back">Dubbelklik voor terug</string>
+    <string name="volume_double_click_back_summary">Tik twee keer op een volumetoets om terug te gaan; één tik slaat de pagina om na een korte vertraging. Vereist bladeren met volumetoetsen.</string>
     <string name="folder_name">Bladwijzermap-naam</string>
     <string name="folder_name_description">Voer de bladwijzermap-naam in</string>
     <string name="setting_title_export_bookmarks">Bladwijzers exporteren</string>

--- a/app/src/main/res/values-no/strings.xml
+++ b/app/src/main/res/values-no/strings.xml
@@ -532,6 +532,8 @@
     <string name="volume_page_turn_summary">Bruk volumtastene til å bla i sider</string>
     <string name="volume_page_turn_paused">Sidebytting med volumtast satt på pause i 5 sekunder</string>
     <string name="volume_page_turn_resumed">Sidebytting med volumtast gjenopptatt</string>
+    <string name="volume_double_click_back">Dobbeltklikk for tilbake</string>
+    <string name="volume_double_click_back_summary">Dobbelttrykk på en volumtast for å gå tilbake; ett trykk blar om siden etter en kort forsinkelse. Krever blaing med volumtaster.</string>
     <string name="web_content_processing">Nettinnholdsbehandling</string>
     <string name="web_processing_gpt_type">AI-motor for sidechat</string>
     <string name="setting_title_default_ai_engine">Standard AI-motor</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -235,6 +235,8 @@
     <string name="volume_page_turn_summary">Przewijaj strony klawiszami głośności</string>
     <string name="volume_page_turn_paused">Przewracanie stron klawiszami głośności wstrzymane na 5 sekund</string>
     <string name="volume_page_turn_resumed">Przewracanie stron klawiszami głośności wznowione</string>
+    <string name="volume_double_click_back">Podwójne naciśnięcie cofa</string>
+    <string name="volume_double_click_back_summary">Naciśnij dwukrotnie klawisz głośności, aby cofnąć; pojedyncze naciśnięcie przewraca stronę po krótkim opóźnieniu. Wymaga przewracania stron klawiszami głośności.</string>
     <string name="folder_name">Nazwa folderu zakładek</string>
     <string name="folder_name_description">Wpisz nazwę folderu zakładek</string>
     <string name="setting_title_export_bookmarks">Eksportuj zakładki</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -210,6 +210,8 @@
     <string name="volume_page_turn_summary">Usar as teclas de volume para mudar de página</string>
     <string name="volume_page_turn_paused">Mudança de página por volume pausada durante 5 segundos</string>
     <string name="volume_page_turn_resumed">Mudança de página por volume retomada</string>
+    <string name="volume_double_click_back">Duplo clique para voltar</string>
+    <string name="volume_double_click_back_summary">Toque duas vezes numa tecla de volume para voltar; um único toque muda de página após um breve atraso. Requer mudança de página com as teclas de volume.</string>
     <string name="folder_name">Nome da pasta de marcadores</string>
     <string name="folder_name_description">Insira o nome da pasta de marcadores</string>
     <string name="setting_title_export_bookmarks">Exportar marcadores</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -228,6 +228,8 @@
     <string name="volume_page_turn_summary">Folosește tastele de volum pentru a schimba pagina</string>
     <string name="volume_page_turn_paused">Schimbarea paginii cu volum în pauză 5 secunde</string>
     <string name="volume_page_turn_resumed">Schimbarea paginii cu volum reluată</string>
+    <string name="volume_double_click_back">Dublu clic pentru înapoi</string>
+    <string name="volume_double_click_back_summary">Apasă de două ori o tastă de volum pentru a merge înapoi; o singură apăsare schimbă pagina după o scurtă întârziere. Necesită schimbarea paginii cu tastele de volum.</string>
     <string name="folder_name">Numele dosarului de marcaje</string>
     <string name="folder_name_description">Introduceți numele dosarului de marcaje</string>
     <string name="setting_title_export_bookmarks">Export marcaje</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -587,6 +587,8 @@
     <string name="url_empty">URL пуст</string>
     <string name="volume_page_turn_paused">Перелистывание кнопками громкости приостановлено на 5 секунд</string>
     <string name="volume_page_turn_resumed">Перелистывание кнопками громкости возобновлено</string>
+    <string name="volume_double_click_back">Двойное нажатие — назад</string>
+    <string name="volume_double_click_back_summary">Дважды нажмите клавишу громкости, чтобы вернуться назад; одиночное нажатие перелистывает страницу с небольшой задержкой. Требуется перелистывание страниц клавишами громкости.</string>
     <string name="web_content_processing">Обработка веб-контента</string>
     <string name="web_processing_gpt_type">Движок ИИ для чата со страницей</string>
     <string name="setting_title_default_ai_engine">Движок ИИ по умолчанию</string>

--- a/app/src/main/res/values-sat/strings.xml
+++ b/app/src/main/res/values-sat/strings.xml
@@ -582,6 +582,8 @@
     <string name="vertical_line">ᱥᱤᱫᱷ ᱜᱟᱨ</string>
     <string name="volume_page_turn_paused">ᱵᱷᱚᱞᱭᱩᱢ ᱥᱟᱦᱴᱟ ᱯᱟᱞᱴᱟᱣ 5 ᱥᱮᱠᱮᱱᱰ ᱞᱟᱹᱜᱤᱫ ᱵᱚᱸᱫ ᱟᱠᱟᱱᱟ</string>
     <string name="volume_page_turn_resumed">ᱵᱷᱚᱞᱭᱩᱢ ᱥᱟᱦᱴᱟ ᱯᱟᱞᱴᱟᱣ ᱫᱩᱦᱲᱟᱹ ᱪᱟᱹᱞᱩ ᱟᱠᱟᱱᱟ</string>
+    <string name="volume_double_click_back">Double-click for back</string>
+    <string name="volume_double_click_back_summary">Double-tap a volume key to go back; a single tap turns the page after a short delay. Requires volume key page turn.</string>
     <string name="web_content_processing">ᱣᱮᱵᱽ ᱡᱤᱱᱤᱥ ᱯᱨᱚᱥᱮᱥ</string>
     <string name="web_processing_gpt_type">GPT ᱤᱧᱡᱤᱱ</string>
     <string name="setting_title_default_ai_engine">ᱢᱩᱞ AI ᱤᱧᱡᱤᱱ</string>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -532,6 +532,8 @@
     <string name="volume_page_turn_summary">Користите тастере за јачину звука за листање страница</string>
     <string name="volume_page_turn_paused">Окретање страница дугмадима за јачину звука паузирано на 5 секунди</string>
     <string name="volume_page_turn_resumed">Окретање страница дугмадима за јачину звука настављено</string>
+    <string name="volume_double_click_back">Двоструки клик за назад</string>
+    <string name="volume_double_click_back_summary">Двапут притисните тастер за јачину звука да бисте се вратили назад; један притисак листа страницу након кратког кашњења. Захтева листање страница тастерима за јачину звука.</string>
     <string name="web_content_processing">Обрада веб садржаја</string>
     <string name="web_processing_gpt_type">AI мотор за ћаскање са страницом</string>
     <string name="setting_title_default_ai_engine">Подразумевани AI мотор</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -532,6 +532,8 @@
     <string name="volume_page_turn_summary">Använd volymknapparna för att bläddra mellan sidor</string>
     <string name="volume_page_turn_paused">Sidbyte med volymknapp pausat i 5 sekunder</string>
     <string name="volume_page_turn_resumed">Sidbyte med volymknapp återupptaget</string>
+    <string name="volume_double_click_back">Dubbelklick för bakåt</string>
+    <string name="volume_double_click_back_summary">Dubbeltryck på en volymknapp för att gå bakåt; ett enkelt tryck bläddrar sidan efter en kort fördröjning. Kräver bläddring med volymknapparna.</string>
     <string name="web_content_processing">Webbinnehållsbearbetning</string>
     <string name="web_processing_gpt_type">AI-motor för sidchatt</string>
     <string name="setting_title_default_ai_engine">Standard AI-motor</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -243,6 +243,8 @@
     <string name="volume_page_turn_summary">Sayfaları çevirmek için ses tuşlarını kullanın</string>
     <string name="volume_page_turn_paused">Ses tuşuyla sayfa çevirme 5 saniye duraklatıldı</string>
     <string name="volume_page_turn_resumed">Ses tuşuyla sayfa çevirme devam etti</string>
+    <string name="volume_double_click_back">Geri gitmek için çift tıklama</string>
+    <string name="volume_double_click_back_summary">Geri gitmek için bir ses tuşuna iki kez basın; tek basış kısa bir gecikmeyle sayfayı çevirir. Ses tuşlarıyla sayfa çevirme özelliğinin açık olması gerekir.</string>
     <string name="folder_name">Yer imi klasörü adı</string>
     <string name="folder_name_description">Yer imi klasörü adını girin</string>
     <string name="setting_title_export_bookmarks">Yer imlerini dışa aktar</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -523,6 +523,8 @@
     <string name="volume_page_turn_summary">Гортання сторінок клавішами гучності</string>
     <string name="volume_page_turn_paused">Перегортання кнопками гучності призупинено на 5 секунд</string>
     <string name="volume_page_turn_resumed">Перегортання кнопками гучності відновлено</string>
+    <string name="volume_double_click_back">Подвійне натискання — назад</string>
+    <string name="volume_double_click_back_summary">Двічі натисніть клавішу гучності, щоб повернутися назад; одиночне натискання гортає сторінку з невеликою затримкою. Потребує гортання сторінок клавішами гучності.</string>
     <string name="web_content_processing">Обробка веб-вмісту</string>
     <string name="web_processing_gpt_type">Движок ШІ для чату зі сторінкою</string>
     <string name="setting_title_default_ai_engine">Движок ШІ за замовчуванням</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -533,6 +533,8 @@
     <string name="volume_page_turn_summary">Dùng phím âm lượng để lật trang</string>
     <string name="volume_page_turn_paused">Lật trang bằng phím âm lượng đã tạm dừng 5 giây</string>
     <string name="volume_page_turn_resumed">Lật trang bằng phím âm lượng đã tiếp tục</string>
+    <string name="volume_double_click_back">Nhấn đúp để quay lại</string>
+    <string name="volume_double_click_back_summary">Nhấn đúp phím âm lượng để quay lại; nhấn một lần sẽ lật trang sau một khoảng trễ ngắn. Yêu cầu bật lật trang bằng phím âm lượng.</string>
     <string name="web_content_processing">Xử lý nội dung web</string>
     <string name="web_processing_gpt_type">Engine AI cho trò chuyện trang web</string>
     <string name="setting_title_default_ai_engine">Engine AI mặc định</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -519,6 +519,8 @@
     <string name="url_empty">网址为空</string>
     <string name="volume_page_turn_paused">音量键翻页已暂停5秒</string>
     <string name="volume_page_turn_resumed">音量键翻页已恢复</string>
+    <string name="volume_double_click_back">双击返回</string>
+    <string name="volume_double_click_back_summary">双击音量键可返回；单击会在短暂延迟后翻页。需要开启音量键翻页。</string>
     <string name="site_force_viewport_width">强制视口宽度 (px)</string>
     <string name="site_force_viewport_width_hint">仅当桌面UA不足时使用</string>
     <string name="search_settings_hint">搜索设置…</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -553,6 +553,8 @@
     <string name="twitter">Twitter</string>
     <string name="volume_page_turn_paused">音量鍵翻頁已暫停 5 秒</string>
     <string name="volume_page_turn_resumed">音量鍵翻頁已恢復</string>
+    <string name="volume_double_click_back">雙擊返回</string>
+    <string name="volume_double_click_back_summary">雙擊音量鍵可返回；單擊會在短暫延遲後翻頁。需開啟音量鍵翻頁。</string>
 
     <!-- Gesture action catalog -->
     <string name="action_category_tab">分頁</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -267,6 +267,8 @@
     <string name="volume_page_turn_summary">Use volume up/down keys to turn pages</string>
     <string name="volume_page_turn_paused">Volume page turn paused for 5 seconds</string>
     <string name="volume_page_turn_resumed">Volume page turn resumed</string>
+    <string name="volume_double_click_back">Double-click for back</string>
+    <string name="volume_double_click_back_summary">Double-tap a volume key to go back. Single taps still turn the page, but wait briefly to detect a second tap.</string>
     <string name="folder_name">Bookmark folder name</string>
     <string name="folder_name_description">Insert Bookmark folder name</string>
     <string name="setting_title_export_bookmarks">Export bookmarks</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -268,7 +268,7 @@
     <string name="volume_page_turn_paused">Volume page turn paused for 5 seconds</string>
     <string name="volume_page_turn_resumed">Volume page turn resumed</string>
     <string name="volume_double_click_back">Double-click for back</string>
-    <string name="volume_double_click_back_summary">Double-tap a volume key to go back. Single taps still turn the page, but wait briefly to detect a second tap.</string>
+    <string name="volume_double_click_back_summary">Double-tap a volume key to go back; a single tap turns the page after a short delay. Requires volume key page turn.</string>
     <string name="folder_name">Bookmark folder name</string>
     <string name="folder_name_description">Insert Bookmark folder name</string>
     <string name="setting_title_export_bookmarks">Export bookmarks</string>


### PR DESCRIPTION
## What

Adds an opt-in gesture: **double-tap either volume key to go Back**. New toggle under **Settings → Gesture → "Double-click for back"**, defaulting **off** — nothing changes for existing users unless they enable it.

## How it works

Volume keys already turn pages (`KeyHandler`). When the new toggle is on:

- **Single tap** still turns the page, but the turn is deferred by a 250ms window so a second tap can be detected.
- **Double tap** (same key, within the window) cancels the pending page turn and calls `handleBackKey()`.
- **Long-press** still adjusts system volume; holding cancels any pending page turn.

The deferral only exists when the feature is enabled, so users who don't opt in keep instant page turns. The window is a single constant (`DOUBLE_CLICK_WINDOW_MS`) for easy tuning.

## Changes

- `TouchConfig`: new `volumeDoubleClickBack` preference (default `false`)
- `KeyHandler`: debounce + double-click detection, coroutine-based like the existing re-enable logic
- `GestureSettings`: toggle row under the existing Volume-key setting
- `strings.xml`: label + summary

## Testing

`./gradlew :app:compileDebugKotlin` and `:app:assembleDebug` pass. Behavioral tuning of the 250ms window is best done on e-ink hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)