### PR TITLE
fix(translate): stop in-place translation from requesting each paragraph twice

### DIFF
--- a/app/src/main/assets/text_node_monitor.js
+++ b/app/src/main/assets/text_node_monitor.js
@@ -11,6 +11,10 @@ function _translateNormalize(s) {
 function _applyTranslationToElement(el, responseString) {
     if (!el) return false;
     if (window._translateInPlace) {
+        // Already translated — a duplicate/late response. Re-applying would churn the
+        // text nodes (visible refresh on e-ink) and overwrite the original-HTML backup
+        // below with already-translated content.
+        if (el.hasAttribute('data-original-html')) return true;
         el.setAttribute('data-original-html', el.innerHTML);
         // Replace only text nodes to preserve links, styles, and other elements.
         // Skip whitespace-only text nodes — they're source-formatting whitespace sitting
@@ -47,11 +51,7 @@ function _applyTranslationToElement(el, responseString) {
 }
 
 function myCallback(elementId, originalText, responseString) {
-    // Cache so future re-renders of the same text apply instantly without a round-trip
-    // (and so the element-replacement scenario below has data to work with).
     var key = _translateNormalize(originalText);
-    if (key) window._translateTextCache.set(key, responseString);
-
     var el = document.getElementById(elementId);
     if (!el) {
         // SPAs (e.g. news.daum.net) often re-render between request and response, killing the
@@ -64,6 +64,17 @@ function myCallback(elementId, originalText, responseString) {
             }
         }
     }
+
+    // Empty response = the native side failed to translate. Clear the in-flight flag so a
+    // later IntersectionObserver event or rebind scan can retry this element.
+    if (!responseString) {
+        if (el) window._translateRequested.delete(el);
+        return;
+    }
+
+    // Cache so future re-renders of the same text apply instantly without a round-trip
+    // (and so the element-replacement scenario above has data to work with).
+    if (key) window._translateTextCache.set(key, responseString);
     _applyTranslationToElement(el, responseString);
 }
 
@@ -78,26 +89,29 @@ function getTranslatableText(element) {
     return window._translateGetTextExcludingImages(element);
 }
 
-// Disconnect previous observer if re-injected
-if (window._translateObserver) {
-    window._translateObserver.disconnect();
-}
-
-window._translateObserver = new IntersectionObserver((entries) => {
+// Reuse the observer across re-injections. Recreating it (with disconnect) would orphan
+// every node already in _translateObservedNodes: they'd be detached from the old observer
+// but skipped by the rebind loop, so off-screen content would never translate on scroll.
+// The callback resolves maybeRequestTranslation/getTranslatableText as globals at call
+// time, so re-injected definitions apply to the reused observer too.
+window._translateObserver = window._translateObserver || new IntersectionObserver((entries) => {
   entries.forEach((entry) => {
-    if (entry.isIntersecting) {
-      var text = getTranslatableText(entry.target);
-      if (text.trim() === "") return;
-      if (window._translateInPlace) {
-          if (!entry.target.hasAttribute('data-original-html')) {
-              androidApp.getTranslation(text, entry.target.id, "myCallback");
-          }
-      } else {
-          var nextNode = entry.target.nextElementSibling;
-          if (nextNode && nextNode.textContent === "") {
-              androidApp.getTranslation(text, entry.target.id, "myCallback");
-          }
-      }
+    if (!entry.isIntersecting) return;
+    if (window._translateInPlace) {
+      // Single request path shared with the rebind scan: checks data-original-html,
+      // the text cache, AND _translateRequested — otherwise this callback re-requests
+      // elements whose bind-time request is still awaiting its response.
+      maybeRequestTranslation(entry.target);
+      return;
+    }
+    var text = getTranslatableText(entry.target);
+    if (text.trim() === "") return;
+    var nextNode = entry.target.nextElementSibling;
+    // The empty-sibling check only holds until the response arrives, so guard in-flight
+    // requests with _translateRequested here too.
+    if (nextNode && nextNode.textContent === "" && !window._translateRequested.has(entry.target)) {
+      window._translateRequested.add(entry.target);
+      androidApp.getTranslation(text, entry.target.id, "myCallback");
     }
   });
 }, { rootMargin: "400px" });

--- a/app/src/main/java/info/plateaukao/einkbro/browser/JsWebInterface.kt
+++ b/app/src/main/java/info/plateaukao/einkbro/browser/JsWebInterface.kt
@@ -96,7 +96,10 @@ class JsWebInterface(
                 }
 
                 withContext(Dispatchers.Main) {
-                    if (webView.isAttachedToWindow && translatedString.isNotEmpty()) {
+                    // Invoke the callback even when translation failed (empty string):
+                    // the JS side uses it to clear the element's in-flight flag so a
+                    // later visibility event can retry instead of blocking it forever.
+                    if (webView.isAttachedToWindow) {
                         webView.evaluateJavascript(
                             "$callback('$elementId', '${escapeForJs(originalText)}', '${escapeForJs(translatedString)}')",
                             null


### PR DESCRIPTION
## Problem

On news.naver.com (and any DOM-churning site), in-place translation visibly re-translated paragraphs: text would render, then re-render with a slightly different translation, and every paragraph cost 2+ LLM API calls.

## Root cause

`text_node_monitor.js` has two independent request paths with disjoint dedup guards:

1. **Bind-time scan** — `bindObserverToTargets()` → `maybeRequestTranslation()`, guarded by the `_translateRequested` WeakSet.
2. **IntersectionObserver** — its in-place branch guarded only on `data-original-html`, an attribute set when a *response is applied*, seconds later. It neither checked nor updated `_translateRequested`.

So every visible element was requested by path 1 and again ~80ms later by path 2's initial delivery. On naver, constant DOM mutations re-ran the rebind loop and scrolling re-crossed the ±400px rootMargin, re-firing any element whose response was still pending (observed up to 5x for one element). Each duplicate response was applied in place — a visible re-translation (and a double refresh on e-ink) — and the second apply overwrote the `data-original-html` backup with already-translated text, breaking original-text restoration.

Verified by proxying `androidApp.getTranslation` in the live WebView: **75 calls for 47 elements** (28 requested twice), 63 API calls for 45 unique texts, 33 of 47 backups corrupted.

## Fix

- Route the IntersectionObserver's in-place branch through `maybeRequestTranslation()` so both paths share one guard set (`data-original-html` + text cache + `_translateRequested`).
- Add the same in-flight guard to the sibling (by-paragraph) branch, which had the identical race on its empty-`nextElementSibling` check.
- Reuse the IntersectionObserver across re-injections instead of disconnect-and-recreate, which orphaned already-observed nodes (detached from the old observer but skipped by the rebind loop) so off-screen content could never translate after a second injection.
- Skip `_applyTranslationToElement` when `data-original-html` already exists, so late duplicates can't churn text nodes or corrupt the backup.
- `JsWebInterface.getTranslation` now invokes the callback even on failure (empty string); the JS side clears the in-flight flag so the element can be retried instead of being blocked forever.

## Verification (same instrumentation, news.naver.com article, OpenAI in-place)

| | before | after |
|---|---|---|
| initial view | 75 calls / 47 elements (28 dup) | 46 / 46 (0 dup) |
| after 5 pages of scrolling | 3–5x per pending paragraph | 68 / 68 (0 dup) |
| corrupted `data-original-html` backups | 33 of 47 | 0 |
| visible untranslated leftovers | up to 29 stuck | 0 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)