### PR TITLE
Fix menu readability on big screens

### DIFF
--- a/app/src/main/java/info/plateaukao/einkbro/view/dialog/compose/MenuDialogFragment.kt
+++ b/app/src/main/java/info/plateaukao/einkbro/view/dialog/compose/MenuDialogFragment.kt
@@ -624,13 +624,15 @@ fun MenuItem(
     val pressed by interactionSource.collectIsPressedAsState()
 
     val configuration = LocalConfiguration.current
+    var isBigScreen = configuration.screenWidthDp > 450
+
     val width = when {
-        isLargeType -> if (configuration.screenWidthDp > 500) 62.dp else 50.dp
-        configuration.screenWidthDp > 500 -> 55.dp
+        isLargeType -> if (isBigScreen) 62.dp else 50.dp
+        isBigScreen -> 60.dp
         else -> 45.dp
     }
 
-    val fontSize = if (!showIcon) 16.sp else if (configuration.screenWidthDp > 500) 10.sp else 8.sp
+    val fontSize = if (!showIcon) 16.sp else if (isBigScreen) 11.sp else 8.sp
 
     // In reorder mode we hand gesture control to the outer ReorderableItem's
     // longPressDraggableHandle — combinedClickable here would consume long-press first.


### PR DESCRIPTION
The 450 dp and more wide screen has enough space to render a slightly larger font, improving readability.

<img width="3000" height="4000" alt="before" src="https://github.com/user-attachments/assets/3f720311-bcce-40cd-870f-b1d6b324ab37" />
<img width="3000" height="4000" alt="after" src="https://github.com/user-attachments/assets/9d39d866-abb2-4cd7-b3b0-00bde2d198d3" />
